### PR TITLE
은지 - 공연장 이름 검색 기능 추가!!! theater_data수정.sql 필수로 돌려주세요!!!

### DIFF
--- a/tickets/sql/theater_data수정.sql
+++ b/tickets/sql/theater_data수정.sql
@@ -1,0 +1,2147 @@
+drop table THEATER;
+
+CREATE TABLE THEATER ( 
+no NUMBER(38),
+  location VARCHAR2(50),
+  city VARCHAR2(50),
+  address VARCHAR2(100),
+  name VARCHAR2(100),
+  total_seat NUMBER(38)
+  );
+--행 1
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1,'서울특별시','강남구','삼성로 154','강남 구민회관',512);
+--행 2
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (2,'서울특별시','강남구','역삼로 7-16, 3층','역삼1문화센터 대강당',236);
+--행 3
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (3,'서울특별시','강남구','남부순환로378길 34-9','도곡2소극장',141);
+--행 4
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (4,'서울특별시','강남구','논현로 508, GS강남타워 5층 ','LG아트센터',1103);
+--행 5
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (5,'서울특별시','강남구','영동대로 511, 트레이드타워 5층 ','코엑스아티움',738);
+--행 6
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (6,'서울특별시','강남구','압구정로22길 21','광림교회 장천홀',613);
+--행 7
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (7,'서울특별시','강남구','일원로 90','세라믹팔세스홀',438);
+--행 8
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (8,'서울특별시','강남구','테헤란로113길 7','백암아트홀',424);
+--행 9
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (9,'서울특별시','강남구','영동대로 416','KT&G상상마당 대치아트홀',416);
+--행 10
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (10,'서울특별시','강남구','언주로 844','윤당아트홀 1관',259);
+--행 11
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (11,'서울특별시','강남구','언주로 844','윤당아트홀 2관',146);
+--행 12
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (12,'서울특별시','강남구','선릉로 지하 806','일지아트홀',240);
+--행 13
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (13,'서울특별시','강남구','테헤란로92길 12-9','한국문화의 집 KOUS',236);
+--행 14
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (14,'서울특별시','강남구','선릉로111길 6 ','성암아트센터',201);
+--행 15
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (15,'서울특별시','강남구','영동대로 511 ','코엑스아트홀',176);
+--행 16
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (16,'서울특별시','강남구','봉은사로 406 ','민속극장 풍류',151);
+--행 17
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (17,'서울특별시','강남구','논현로4길 36 ','M극장',150);
+--행 18
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (18,'서울특별시','강남구','테헤란로 117 ','KB아트홀',147);
+--행 19
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (19,'서울특별시','강남구','논현로 816, ICL빌딩 1층 ','마이라이브홀',102);
+--행 20
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (20,'서울특별시','강남구','학동로 171, 3층 ','삼익피아노 홀',100);
+--행 21
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (21,'서울특별시','강남구','강남대로 600, 동신빌딩 지하02층 ','스페이스 바움',100);
+--행 22
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (22,'서울특별시','강남구','학동로 171, 삼익악기 빌딩 3층 ','삼익엠팟홀',100);
+--행 23
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (23,'서울특별시','강남구','언주로173길 20 ','세실 아트홀',100);
+--행 24
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (24,'서울특별시','강남구','선릉로 547, 지하층 ','파인트리 시어터',100);
+--행 25
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (25,'서울특별시','강남구','도산대로89길 8, LH빌딩 지하1층 ','알디뮤직',80);
+--행 26
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (26,'서울특별시','강남구','영동대로 315, 지하1층 ','마리아칼라스홀',51);
+--행 27
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (27,'서울특별시','강남구','논현로117길 17, 지하층 ','엑스스페이스',50);
+--행 28
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (28,'서울특별시','강남구','테헤란로 337, 화남타워 지하 ','아트홀가얏고을',77);
+--행 29
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (29,'서울특별시','강남구','봉은사로 446, 슈피겐HQ A동 ','슈피겐홀',72);
+--행 30
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (30,'서울특별시','강남구','논현로163길 33 ','광림아트센터 BBCH홀',1006);
+--행 31
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (31,'서울특별시','강남구','언주로133길 11 ','플랫폼라이브',172);
+--행 32
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (32,'서울특별시','강남구','선릉로 806, 3,4층 ','광야아트센터',192);
+--행 33
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (33,'서울특별시','강남구','도산대로49길 8, YK빌딩 지하1층 ','테크인홀',32);
+--행 34
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (34,'서울특별시','강남구','선릉로 814, 엠디가슴성형센터빌딩 B1호 ','미스틱',110);
+--행 35
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (35,'서울특별시','강동구','동남로 870','강동아트센터 대극장 한강',850);
+--행 36
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (36,'서울특별시','강동구','동남로 870','강동아트센터 소극장 드림',250);
+--행 37
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (37,'서울특별시','강동구','성내로6길 16','강동어린이회관',177);
+--행 38
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (38,'서울특별시','강동구','강동구 올림픽로 930','암사어린이극장',287);
+--행 39
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (39,'서울특별시','강동구','강동구 성안로 30','호원아트홀',222);
+--행 40
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (40,'서울특별시','강북구','삼각산로 85','강북문화예술회관',666);
+--행 41
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (41,'서울특별시','강서구','우장산로 66','강서구민회관 우장홀',609);
+--행 42
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (42,'서울특별시','관악구','신림로3길 35','관악문화관도서관',698);
+--행 43
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (43,'서울특별시','광진구','능동로76','나루아트센터 소공연장',167);
+--행 44
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (44,'서울특별시','광진구','능동로76','나루아트센터 대공연장',601);
+--행 45
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (45,'서울특별시','구로구','가마산로25길 9-24','구로아트밸리예술극장',611);
+--행 46
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (46,'서울특별시','구로구','경인로20가길 38','오류문화센터 오류아트홀',365);
+--행 47
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (47,'서울특별시','구로구','구로동로26길 54, 4층','꿈나무극장',153);
+--행 48
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (48,'서울특별시','구로구','가마산로25길 33','구로구민회관',531);
+--행 49
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (49,'서울특별시','구로구','구로동 3-33','신도림오페라하우스',533);
+--행 50
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (50,'서울특별시','구로구','구로중앙로 134 지하','예술나무씨어터',278);
+--행 51
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (51,'서울특별시','구로구','경인로 662','디큐브아트센터',1242);
+--행 52
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (52,'서울특별시','구로구','디지털로32가길 25, 203호','칸테움극장',60);
+--행 53
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (53,'서울특별시','노원구','중계로 181','노원문화예술회관 대공연장 ',608);
+--행 54
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (54,'서울특별시','노원구','중계로 181','노원문화예술회관 소공연장 ',292);
+--행 55
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (55,'서울특별시','노원구','노해로 502','노원어울림극장',282);
+--행 56
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (56,'서울특별시','노원구','광운로 20','동해문화예술관 대극장',2005);
+--행 57
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (57,'서울특별시','도봉구','도봉로 552','도봉구민회관 대강당',550);
+--행 58
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (58,'서울특별시','도봉구','도봉로 552','도봉구민회관 소공연장',192);
+--행 59
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (59,'서울특별시','도봉구','마들로932. 평화문화진지','BUNKER 1-1 씨어터',300);
+--행 60
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (60,'서울특별시','도봉구','마들로11길 74','레드박스',144);
+--행 61
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (61,'서울특별시','도봉구','노해로 69길 132','시립창동문화체육센터 공연장',188);
+--행 62
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (62,'서울특별시','도봉구','노해로391. 네네빌딩B2','창동극장',100);
+--행 63
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (63,'서울특별시','동작구','사당로 143','콘서트홀',453);
+--행 64
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (64,'서울특별시','동작구','상도로30길 8','국화소극장',40);
+--행 65
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (65,'서울특별시','마포구','대흥로20길 28','마포아트센터 아트홀맥',733);
+--행 66
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (66,'서울특별시','마포구','대흥로20길 28','마포아트센터 플레이맥',201);
+--행 67
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (67,'서울특별시','마포구','와우산로 148, 지하 및 1/2층','포스트극장',200);
+--행 68
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (68,'서울특별시','마포구','와우산로 121, 지하1층','에스제이비보이극장',256);
+--행 69
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (69,'서울특별시','마포구','어울마당로 65, 지하1/2층','상상마당 라이브홀',120);
+--행 70
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (70,'서울특별시','마포구','창전로 14','씨제이아지트',140);
+--행 71
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (71,'서울특별시','마포구','와우산로 157, 지하1층','소극장 산울림',76);
+--행 72
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (72,'서울특별시','마포구','어울마당로 94-8, 지하1층','정태호소극장',100);
+--행 73
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (73,'서울특별시','마포구','고산길 32, 지하1층','얘기 아트 시어터',100);
+--행 74
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (74,'서울특별시','마포구','월드컵북로2길 49','청년문화공간JU동교동 다리소극장',200);
+--행 75
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (75,'서울특별시','마포구','어울마당로 35, 지하1층','롤링홀',80);
+--행 76
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (76,'서울특별시','마포구','양화로16길 29, 지하 2,3층','홍대난타극장',370);
+--행 77
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (77,'서울특별시','마포구','홍익로 25, 지하3층','하나투어 브이홀',252);
+--행 78
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (78,'서울특별시','마포구','포은로 14, 지하1층','임혁필 소극장',92);
+--행 79
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (79,'서울특별시','마포구','양화로 45, 2층','신한카드 FAN 스퀘어 라이브홀',424);
+--행 80
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (80,'서울특별시','마포구','독막로15길 3-12, 지하1층','아트홀 베짱이',250);
+--행 81
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (81,'서울특별시','마포구','양화로 45, 2층','신한카드 FAN 스퀘어 드림홀',296);
+--행 82
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (82,'서울특별시','마포구','와우산로 117, 지하1층','김대범소극장',99);
+--행 83
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (83,'서울특별시','마포구','독막로7길 20, 지하1층','얼라이브홀',111);
+--행 84
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (84,'서울특별시','마포구','월드컵북로 323, 지하1층','제일라아트홀',250);
+--행 85
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (85,'서울특별시','마포구','잔다리로 46, 지하1층','벨로주',62);
+--행 86
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (86,'서울특별시','마포구','잔다리로 32, 지하1층','무브홀',164);
+--행 87
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (87,'서울특별시','마포구','잔다리로6길 5, 지하1층','REDBIG SPACE',88);
+--행 88
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (88,'서울특별시','마포구','와우산로21길 29, 지하1층','윤형빈 소극장',161);
+--행 89
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (89,'서울특별시','마포구','와우산로25길 6, 지하3층','웨스트브릿지 라이브홀',150);
+--행 90
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (90,'서울특별시','마포구','와우산로21길 20-11, 지하층','더 스텀프',86);
+--행 91
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (91,'서울특별시','마포구','동교로 63, 지하1층','클럽 샤프',51);
+--행 92
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (92,'서울특별시','마포구','증산로 87, T2동','문화비축기지 T2 공연장',300);
+--행 93
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (93,'서울특별시','마포구','잔다리로 31, 제우피스 지하1층','JDBSQUARE',115);
+--행 94
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (94,'서울특별시','마포구','만리재로 123, YD레지던스 B103호','문화공간 너나들이',50);
+--행 95
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (95,'서울특별시','마포구','와우산로29가길 15)','구름아래소극장',200);
+--행 96
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (96,'서울특별시','서대문구','이화여대길 52, 지하4층','ECC 삼성홀',708);
+--행 97
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (97,'서울특별시','서대문구','백련사길 39','서대문문화체육회관',589);
+--행 98
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (98,'서울특별시','서대문구','신촌역로 13, 지하1층','퀸라이브홀',100);
+--행 99
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (99,'서울특별시','서대문구','연세로 50, B1층','금호아트홀 연세',390);
+--행 100
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (100,'서울특별시','서대문구','충정로 7, 2층 3층','더 페인터즈 히어로 정동길 전용관',554);
+--행 101
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (101,'서울특별시','서대문구','연희맛로 2-3, 지하1층','연희예술극장',300);
+--행 102
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (102,'서울특별시','서대문구','연세로5다길 10, 지하1층','몽향 라이브 홀',100);
+--행 103
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (103,'서울특별시','서대문구','연세로2나길 57, 지하2층','신촌문화발전소',300);
+--행 104
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (104,'서울특별시','서대문구','성산로 533, 1층','리움홀',76);
+--행 105
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (105,'서울특별시','서초구','강남대로 201','서초문화예술회관 아트홀',657);
+--행 106
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (106,'서울특별시','성동구','뚝섬로1길 43','성수아트홀',350);
+--행 107
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (107,'서울특별시','성동구','왕십리로 281','소월아트홀',520);
+--행 108
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (108,'서울특별시','성동구','살곶이길 200','백남아트홀',208);
+--행 109
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (109,'서울특별시','성동구','왕십리로 241 ','메두사홀 1관',260);
+--행 110
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (110,'서울특별시','성동구','왕십리로 241','메두사홀 2관',209);
+--행 111
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (111,'서울특별시','성동구','왕십리로 241','메두사홀 3관',125);
+--행 112
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (112,'서울특별시','성동구','왕십리로 63 ','언더스탠드에비뉴 아트스탠드',120);
+--행 113
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (113,'서울특별시','성동구','왕십리로 104 ','게토',300);
+--행 114
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (114,'서울특별시','성동구','연무장7길 11 ','우란2경',120);
+--행 115
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (115,'서울특별시','성동구','성덕정길 135-1 ','성수소극장',90);
+--행 116
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (116,'서울특별시','성북구','동소문로 177','미아리고개 예술극장',90);
+--행 117
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (117,'서울특별시','성북구','대사관로 3','삼청각',206);
+--행 118
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (118,'서울특별시','성북구','한천로 660-9, 성북청소년수련관','시립성북청소년센터',169);
+--행 119
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (119,'서울특별시','성북구','화랑로32길 146-37','한국예술종합학교',538);
+--행 120
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (120,'서울특별시','성북구','화랑로32길 146-37','한국예술종합학교',323);
+--행 121
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (121,'서울특별시','성북구','삼선교로 14, 지층 ','극장 봄',55);
+--행 122
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (122,'서울특별시','성북구','동소문로20나길 27, 지층 ','뜻밖의 극장',70);
+--행 123
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (123,'서울특별시','성북구','동소문로 24 ','공간 222',33);
+--행 124
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (124,'서울특별시','성북구','성북로5길 9-3, 지층 ','여행자극장',100);
+--행 125
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (125,'서울특별시','성북구','동소문로20다길 10, 세창빌딩 4층 ','성북마을극장',68);
+--행 126
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (126,'서울특별시','성북구','보문로40길 11, B201호 ','공감M아트센터',70);
+--행 127
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (127,'서울특별시','성북구','화랑로18자길 13, 성북정보도서관 지하1층','천장산 우화극장',100);
+--행 128
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (128,'서울특별시','송파구','올림픽로 240','가든스테이지',350);
+--행 129
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (129,'서울특별시','송파구','올림픽로 240','동화극장',130);
+--행 130
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (130,'서울특별시','송파구','올림픽로 240','샤롯데 씨어터',1227);
+--행 131
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (131,'서울특별시','송파구','올림픽로 424','우리금융아트홀',1184);
+--행 132
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (132,'서울특별시','송파구','올림픽로 424','올림픽홀',2452);
+--행 133
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (133,'서울특별시','송파구','올림픽로 424','뮤즈 라이브',240);
+--행 134
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (134,'서울특별시','송파구','올림픽로 424','K-아트홀',493);
+--행 135
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (135,'서울특별시','송파구','오금로 195','DNG HALL',250);
+--행 136
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (136,'서울특별시','송파구','올림픽로 300','롯데콘서트홀',2036);
+--행 137
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (137,'서울특별시','송파구','백제고분로19길 35','WS Music Hall',60);
+--행 138
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (138,'서울특별시','송파구','위례성대로 18','아트홀제이',30);
+--행 139
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (139,'서울특별시','송파구','올림픽로 25','잠실종합운동장<위윌락유>전용 로열씨어터',1487);
+--행 140
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (140,'서울특별시','양천구','목동서로 367','양천문화회관',684);
+--행 141
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (141,'서울특별시','양천구','목동서로 143','목동청소년수련관',337);
+--행 142
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (142,'서울특별시','양천구','목동서로 201, 1층','KT체임버홀',419);
+--행 143
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (143,'서울특별시','양천구','목동동로 233, 2,3층','코바코홀',290);
+--행 144
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (144,'서울특별시','양천구','목동서로 225, 2~5층','로운아뜨리움 로운아트홀',712);
+--행 145
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (145,'서울특별시','양천구','목동서로 225, 3층','로운아뜨리움 아뜨리움홀',300);
+--행 146
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (146,'서울특별시','영등포구','국회대로 596 영등포구민회관','영등포아트홀 공연장',526);
+--행 147
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (147,'서울특별시','영등포구','여의도동 18번지 ','KBS홀',1661);
+--행 148
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (148,'서울특별시','영등포구','여의도동 12번지 ','영산아트홀',598);
+--행 149
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (149,'서울특별시','영등포구','당산동4가 93-1번지 TCC Center ','TCC아트홀',150);
+--행 150
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (150,'서울특별시','영등포구','여의도동 18번지 ','KBS아트홀',372);
+--행 151
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (151,'서울특별시','영등포구','영등포동5가 24번지 동남상가아파트 ','푸른극장',70);
+--행 152
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (152,'서울특별시','영등포구','당산동5가 7-2번지 유원제일2차아파트상가내 ','창작플랫폼 경험과 상상',50);
+--행 153
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (153,'서울특별시','용산구','녹사평대로 150','용산아트홀 대극장 미르',787);
+--행 154
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (154,'서울특별시','용산구','녹사평대로 150','용산아트홀 소극장 가람',298);
+--행 155
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (155,'서울특별시','용산구','한강대로 372 센트레빌아스테리움 서울KDB생명타워 B2층','동자아트홀',157);
+--행 156
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (156,'서울특별시','용산구','서빙고로 137','극장 용',805);
+--행 157
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (157,'서울특별시','용산구','이태원로 294','블루스퀘어 뮤지컬공연장',1767);
+--행 158
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (158,'서울특별시','용산구','이태원로 294','블루스퀘어 콘서트공연장',1400);
+--행 159
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (159,'서울특별시','용산구','한남대로 98, 지하1층','일신홀',189);
+--행 160
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (160,'서울특별시','용산구','이태원로 246','Under Stage ',188);
+--행 161
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (161,'서울특별시','용산구','한강대로23길 55, 6층 1-1호','대원 콘텐츠 라이브',121);
+--행 162
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (162,'서울특별시','용산구','청파로45길 5','코리아블루스씨어터',40);
+--행 163
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (163,'서울특별시','용산구','한강대로48길 17-6','코리아 임프라브 씨어터',80);
+--행 164
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (164,'서울특별시','용산구','양녕로 445','노들섬 라이브하우스',456);
+--행 165
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (165,'서울특별시','용산구','용산구 신흥로 89, 4층','세계평화운동 커뮤니티센터 월드피스존',50);
+--행 167
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (166,'서울특별시','은평구','녹번로16','은평문화예술회관 공연장',701);
+--행 168
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (167,'서울특별시','종로구','세종대로 175','세종문화회관대극장',3022);
+--행 169
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (168,'서울특별시','종로구','동숭길 100 ','대학로뮤지컬센터 대극장',993);
+--행 170
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (169,'서울특별시','종로구','대학로 57','홍익대 대학로 아트센터 대극장',702);
+--행 171
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (170,'서울특별시','종로구','종로33길 15','두산아트센터 연강홀',620);
+--행 172
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (171,'서울특별시','종로구','세종대로 175','세종M씨어터',609);
+--행 173
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (172,'서울특별시','종로구','대학로8길 7, 한국문예회관','아르코예술극장대극장',600);
+--행 174
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (173,'서울특별시','종로구','대학로12길 64','유니플렉스 1관',599);
+--행 175
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (174,'서울특별시','종로구','동숭길 100 )','대학로뮤지컬센터 중극장',528);
+--행 176
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (175,'서울특별시','종로구','대학로10길 17','대학로예술극장 대극장',504);
+--행 177
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (176,'서울특별시','종로구','돈화문로 13, 5,6층 ','더페인터즈전용관',488);
+--행 178
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (177,'서울특별시','종로구','창신동 222-8번지 ','종로구민회관 대강당',456);
+--행 179
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (178,'서울특별시','종로구','세종대로 175','세종체임버홀',443);
+--행 180
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (179,'서울특별시','종로구','동숭길 148, 지하2층~지하4층','SKON 1관',440);
+--행 181
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (180,'서울특별시','종로구','동숭길 126','동덕 코튼홀',401);
+--행 182
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (181,'서울특별시','종로구','대학로12길 21, 지하3층','예스24스테이지 1관',398);
+--행 183
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (182,'서울특별시','종로구','대학로12길 83','대학로 아트원씨어터 1관',393);
+--행 184
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (183,'서울특별시','종로구','삼일대로 428','우리열린극장',388);
+--행 185
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (184,'서울특별시','종로구','삼일대로 386, 시네코아 4,5층','판시어터',388);
+--행 186
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (185,'서울특별시','종로구','삼일대로 386, 지하2층','시네코아 1관',376);
+--행 187
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (186,'서울특별시','종로구','대학로 146, 4층','판타스틱 전용관',375);
+--행 188
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (187,'서울특별시','종로구','인왕산로1길 21','광화문아트홀',370);
+--행 189
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (188,'서울특별시','종로구','대학로 144','더굿씨어터',369);
+--행 190
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (189,'서울특별시','종로구','동숭길 123, 지하1,2층 ','드림아트센터 1관',357);
+--행 191
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (190,'서울특별시','종로구','동숭동 1-75번지 대학로문화공간 ','대학로 티오엠1관',353);
+--행 192
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (191,'서울특별시','종로구','우정국로 55, 지하2층','전통문화예술공연장',333);
+--행 193
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (192,'서울특별시','종로구','세종대로 175, 세종문화회관','세종S씨어터',330);
+--행 194
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (193,'서울특별시','종로구','대학로12길 73','컬처스페이스 엔유',314);
+--행 195
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (194,'서울특별시','종로구','종로33길 15','두산아트센터 Space111',300);
+--행 196
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (195,'서울특별시','종로구','대학로 132','아티스탄홀',299);
+--행 197
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (196,'서울특별시','종로구','대학로12길 21','예스24스테이지 2관',295);
+--행 198
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (197,'서울특별시','종로구','대학로12길 83','대학로 아트원씨어터 2관',293);
+--행 199
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (198,'서울특별시','종로구','성균관로 91','아이들극장',281);
+--행 200
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (199,'서울특별시','종로구','이화장길 26','제이티앤 아트홀 1관',276);
+--행 201
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (200,'서울특별시','종로구','대학로12길 31','대학로 자유극장',271);
+--행 202
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (201,'서울특별시','종로구','대학로12길 64, 2, 3층','유니플렉스 2관',269);
+--행 203
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (202,'서울특별시','종로구','동숭길 148, 3층','SKON 2관',264);
+--행 204
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (203,'서울특별시','종로구','동숭길 25 ','Sh art hall',260);
+--행 205
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (204,'서울특별시','종로구','대학로12길 21, 3층','예스24스테이지 3관',256);
+--행 206
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (205,'서울특별시','종로구','대학로8가길 79','수상한 흥신소 전용관',250);
+--행 207
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (206,'서울특별시','종로구','동숭동 1-75번지 대학로문화공간 지하3층 ','대학로 티오엠2관',249);
+--행 208
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (207,'서울특별시','종로구','대학로14길 29, 동양예술극장 4층','동양예술극장 1관',245);
+--행 209
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (208,'서울특별시','종로구','대학로10길 24','틴틴홀',244);
+--행 210
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (209,'서울특별시','종로구','창경궁로 254','한성아트홀1관',240);
+--행 211
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (210,'서울특별시','종로구','대학로12길 49','세우아트센타',240);
+--행 212
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (211,'서울특별시','종로구','혜화로 17','눈빛극장',239);
+--행 213
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (212,'서울특별시','종로구','율곡로3길 87, 지하1층','아트선재센터',238);
+--행 214
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (213,'서울특별시','종로구','이화장길 26, 6층','제이티앤 아트홀 4관',232);
+--행 215
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (214,'서울특별시','종로구','대학로10길 5 ','바탕골소극장 2관',232);
+--행 216
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (215,'서울특별시','종로구','이화장길 26 ','제이티앤 아트홀 2관',230);
+--행 217
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (216,'서울특별시','종로구','이화장길 26, 4층','제이티앤 아트홀 3관',230);
+--행 218
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (217,'서울특별시','종로구','대학로10길 12, 지하1층','극장가게',230);
+--행 219
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (218,'서울특별시','종로구','이화장길 94, 2층','엘림홀',228);
+--행 220
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (219,'서울특별시','종로구','대학로14길 29, 동양예술극장 2층~3층','동양예술극장 2관',223);
+--행 221
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (220,'서울특별시','종로구','인사동길 34-1, 비201호','인사아트홀',216);
+--행 222
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (221,'서울특별시','종로구','대학로8길 25, 지하1층','콘텐츠그라운드',213);
+--행 223
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (222,'서울특별시','종로구','대학로12길 22','아트포레스트 1관',212);
+--행 224
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (223,'서울특별시','종로구','동숭길 123, 4층','드림아트센터 3관',211);
+--행 225
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (224,'서울특별시','종로구','동숭길 123, 2층','드림아트센터 2관',211);
+--행 226
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (225,'서울특별시','종로구','대학로10길 15-11, 4층','하마씨어터',210);
+--행 227
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (226,'서울특별시','종로구','동숭길 123, 5층 ','드림아트센터 4관',210);
+--행 228
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (227,'서울특별시','종로구','대학로11길 23 ','후암스테이지 1관',209);
+--행 229
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (228,'서울특별시','종로구','동숭길 130-5, 지하2층 ','예그린씨어터',202);
+--행 230
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (229,'서울특별시','종로구','성균관로 87 ','Ground-SYN',201);
+--행 231
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (230,'서울특별시','종로구','자하문로 242 ','부암아트홀',200);
+--행 232
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (231,'서울특별시','종로구','동숭길 94, 지하1층 ','고스트씨어터',200);
+--행 233
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (232,'서울특별시','종로구','대학로10길 11 ','대학로연극 순위아트홀1관',198);
+--행 234
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (233,'서울특별시','종로구','이화장길 72, 지하1층 ','환상극장',198);
+--행 235
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (234,'서울특별시','종로구','동숭길 55 ','콘텐츠박스',196);
+--행 236
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (235,'서울특별시','종로구','이화장길 54, B1호 ','익스트림씨어터2관',195);
+--행 237
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (236,'서울특별시','종로구','대학로12길 46 ','학전블루소극장',194);
+--행 238
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (237,'서울특별시','종로구','대학로12길 69 ','CJ아지트',190);
+--행 239
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (238,'서울특별시','종로구','대학로10길 5 ','대학로바탕골소극장',190);
+--행 240
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (239,'서울특별시','종로구','대학로12길 15, 지하2층 ','원패스아트홀',182);
+--행 241
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (240,'서울특별시','종로구','대학로12길 64, 4층 ','유니플렉스 3관',181);
+--행 242
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (241,'서울특별시','종로구','대학로8가길 52, 6층 ','스카이씨어터',180);
+--행 243
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (242,'서울특별시','종로구','대학로8가길 80, 지하1층 ','두레홀',180);
+--행 244
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (243,'서울특별시','종로구','이화장길 58, 지하2층 ','졸탄극장',179);
+--행 245
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (244,'서울특별시','종로구','동숭길 25 ','알과핵소극장',177);
+--행 246
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (245,'서울특별시','종로구','창경궁로35길 29 ','JEI ART CENTER 음악홀',175);
+--행 247
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (246,'서울특별시','종로구','이화장길 99 ','스튜디오 76',173);
+--행 248
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (247,'서울특별시','종로구','대학로 120, 지하1층 ','공간 아울',172);
+--행 249
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (248,'서울특별시','종로구','창경궁로 260 ','해오름 예술극장',170);
+--행 250
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (249,'서울특별시','종로구','대학로8가길 30, 지하1층 ','명작극장 2관',170);
+--행 251
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (250,'서울특별시','종로구','대학로12길 83 ','대학로아트원씨어터3관',165);
+--행 252
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (251,'서울특별시','종로구','대학로14길 29, 동양예술극장 1층 ','동양예술극장 3관',162);
+--행 253
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (252,'서울특별시','종로구','대학로10길 24, 동숭동 ','올래홀',162);
+--행 254
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (253,'서울특별시','종로구','대학로 116 ','샘터파랑새극장',160);
+--행 255
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (254,'서울특별시','종로구','창덕궁길 29-4  ','북촌아트홀',160);
+--행 256
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (255,'서울특별시','종로구','대학로11길 23 ','후암스테이지 2관',160);
+--행 257
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (256,'서울특별시','종로구','대학로8가길 36 ','파랑씨어터',160);
+--행 258
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (257,'서울특별시','종로구','자하문로 82 ','경복궁아트홀',155);
+--행 259
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (258,'서울특별시','종로구','대학로12길 22, 지상5층 ','아트포레스트 2관',155);
+--행 260
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (259,'서울특별시','종로구','창경궁로 263 ','예술극장 나무와물',154);
+--행 261
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (260,'서울특별시','종로구','창경궁로 254 ','한성아트홀2관',150);
+--행 262
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (261,'서울특별시','종로구','창경궁로 258-12 ','열린극장',150);
+--행 263
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (262,'서울특별시','종로구','창경궁로 258-9, 지하1층 ','서연아트홀',150);
+--행 264
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (263,'서울특별시','종로구','대학로8가길 30, 2층 ','명작극장',149);
+--행 265
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (264,'서울특별시','종로구','대학로8가길 129, 지하1층 ','물빛극장',146);
+--행 266
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (265,'서울특별시','종로구','창경궁로34길 26, 지하1층 ','라이프시어터',146);
+--행 267
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (266,'서울특별시','종로구','이화장길 72, 2층 ','삼형제극장',145);
+--행 268
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (267,'서울특별시','종로구','대학로3길 9 ','열림홀',143);
+--행 269
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (268,'서울특별시','종로구','대학로 116 +','샘터파랑새극장2관',143);
+--행 270
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (269,'서울특별시','종로구','대학로12길 10, 지하1층 ','썸데이즈홀',142);
+--행 271
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (270,'서울특별시','종로구','대학로 57 ','홍익대 대학로 아트센터 소극장',140);
+--행 272
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (271,'서울특별시','종로구','대학로8가길 80, 5층 ','컬쳐시어터',140);
+--행 273
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (272,'서울특별시','종로구','율곡로 102','서울돈화문국악당',140);
+--행 274
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (273,'서울특별시','종로구','창경궁로 227, 지하1층 ','익스트림씨어터3관',136);
+--행 275
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (274,'서울특별시','종로구','대학로8가길 52, 3층 ','시온아트홀',134);
+--행 276
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (275,'서울특별시','종로구','대학로10길 17','대학로예술극장소극장',132);
+--행 277
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (276,'서울특별시','종로구','혜화로5길 5 ','선돌극장',130);
+--행 278
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (277,'서울특별시','종로구','대학로10길 15-11 ','드림시어터',130);
+--행 279
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (278,'서울특별시','종로구','낙산길 14 ','R&J씨어터',130);
+--행 280
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (279,'서울특별시','종로구','대학로8가길 52, 5층 ','스카이씨어터2관',130);
+--행 281
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (280,'서울특별시','종로구','대학로8가길 129, 3층 ','풀빛극장',128);
+--행 282
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (281,'서울특별시','종로구','동숭길 39, 지2층 ','봄날아트홀 2관',124);
+--행 283
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (282,'서울특별시','종로구','인사동길 34-1, 인사아트플라자 지하2층 ','인사아트홀2',124);
+--행 284
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (283,'서울특별시','종로구','이화장길 86-8, 지층 ','중앙대학교 공연예술원 스튜디오 시어터',120);
+--행 285
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (284,'서울특별시','종로구','대학로 89 ','SJA LIVE HALL',120);
+--행 286
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (285,'서울특별시','종로구','혜화로 35, 지층 ','동숭무대 소극장',120);
+--행 287
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (286,'서울특별시','종로구','대학로8가길 30, 3층 ','마루아트홀',118);
+--행 288
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (287,'서울특별시','종로구','혜화로9길 7 ','나온씨어터',116);
+--행 289
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (288,'서울특별시','종로구','청계천로 279, 지하1층','전통문화공간 창선당',116);
+--행 290
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (289,'서울특별시','종로구','대학로11길 23, 지하2층','대학로스타시티 후암스테이지',115);
+--행 291
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (290,'서울특별시','종로구','대학로8길 7, 한국문예회관 ','아르코예술극장소극장',110);
+--행 292
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (291,'서울특별시','종로구','혜화로 10-3, 지하1층 ','예술공간 혜화',110);
+--행 293
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (292,'서울특별시','종로구','대학로14길 18-2, 지하1층 ','달밤엔씨어터',109);
+--행 294
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (293,'서울특별시','종로구','창경궁로34길 18-12, 지하1층 ','서완소극장',107);
+--행 295
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (294,'서울특별시','종로구','대학로12길 49, 3층 ','세우아트센터 2관',102);
+--행 296
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (295,'서울특별시','종로구','동숭4길 14 ','단막극장',100);
+--행 297
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (296,'서울특별시','종로구','창경궁로35길 21 ','극단연우무대',100);
+--행 298
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (297,'서울특별시','종로구','대학로12길 63 ','소극장 혜화당',100);
+--행 299
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (298,'서울특별시','종로구','동숭길 50 ','마로니에극장',100);
+--행 300
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (299,'서울특별시','종로구','창덕궁길 29-38  ','북촌나래홀',100);
+--행 301
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (300,'서울특별시','종로구','창덕궁길 29-6 ','북촌창우극장',100);
+--행 302
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (301,'서울특별시','종로구','이화장길 78 ','마당세실극장',100);
+--행 303
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (302,'서울특별시','종로구','대학로8가길 66, 지하1층 ','노을소극장',100);
+--행 304
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (303,'서울특별시','종로구','대학로11길 38-11, 지하1층 ','피카소소극장',99);
+--행 305
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (304,'서울특별시','종로구','대학로3길 10, 지하2층 ','더 씨어터',96);
+--행 306
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (305,'서울특별시','종로구','동숭길 140, 지하1층 ','낙산씨어터',92);
+--행 307
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (306,'서울특별시','종로구','대학로8가길 48, 4층 ','아루또 소극장',90);
+--행 308
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (307,'서울특별시','종로구','창경궁로 259 ','극장 동국',86);
+--행 309
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (308,'서울특별시','종로구','성균관로4길 42, 지하1층 ','지즐 소극장',84);
+--행 310
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (309,'서울특별시','종로구','동숭길 74, 지하1층 ','댕로홀',83);
+--행 311
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (310,'서울특별시','종로구','성균관로4길 48 ','대학로 아름다운 극장',80);
+--행 312
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (311,'서울특별시','종로구','성균관로3길 23, 지하1층 ','아트씨어터 문',80);
+--행 313
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (312,'서울특별시','종로구','동숭길 39, 지하1층 ','봄날아트홀 1관',80);
+--행 314
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (313,'서울특별시','종로구','성균관로 12-3, 지하층 ','성균소극장',80);
+--행 315
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (314,'서울특별시','종로구','성균관로4길 19, 지하층 ','예술공간 서울',80);
+--행 316
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (315,'서울특별시','종로구','창경궁로 303, 지하1층 ','소극장 공유',80);
+--행 317
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (316,'서울특별시','종로구','돈화문로 88-1, B1호 ','창덕궁 소극장',80);
+--행 318
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (317,'서울특별시','종로구','혜화로 4, 지하1층 ','맛있는 극장',70);
+--행 319
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (318,'서울특별시','종로구','성균관로 15-10, 지하1층 ','스튜디오 성균',70);
+--행 320
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (319,'서울특별시','종로구','성균관로3길 20-4, 지하1층 ','허수아비 소극장',63);
+--행 321
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (320,'서울특별시','종로구','동숭길 76, 지하1층 ','해바라기 소극장',61);
+--행 322
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (321,'서울특별시','종로구','창경궁로35길 7, 지하1층 ','연극실험실 혜화동1번지',60);
+--행 323
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (322,'서울특별시','종로구','창경궁로35길 17 ','한얼소극장',50);
+--행 324
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (323,'서울특별시','종로구','필운대로7길 12, 지하1층 ','서촌공간서로',50);
+--행 325
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (324,'서울특별시','종로구','이화장1길 24, 지하1층 ','북극곰 소극장',50);
+--행 326
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (325,'서울특별시','종로구','수표로28길 7, 양지빌딩 4층 ','월하예당',40);
+--행 327
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (326,'서울특별시','중구','퇴계로 387','충무아트센터 대극장',1231);
+--행 328
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (327,'서울특별시','중구','퇴계로 387','충무아트센터 중극장',327);
+--행 329
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (328,'서울특별시','중구','퇴계로 387','충무아트센터 소극장',225);
+--행 330
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (329,'서울특별시','중랑구','면목로 238 ','중랑구민회관',494);
+--행 331
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (330,'부산광역시','강서구','명지오션시티4로 88, 8층','성원아트홀',174);
+--행 332
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (331,'부산광역시','금정구','체육공원로 7','금정문화회관',1198);
+--행 333
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (332,'부산광역시','금정구','체육공원로399번길 324','꿈나래 어린이극장',197);
+--행 334
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (333,'부산광역시','금정구','부산대학로63번길2 NC부산대점','엔씨소극장',202);
+--행 335
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (334,'부산광역시','금정구','장전온천천로113번길 17','증인아트홀',53);
+--행 336
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (335,'부산광역시','금정구','금강로 321번길 15','셔우드홀',60);
+--행 337
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (336,'부산광역시','금정구','공단동로55번길 28','Campus D고촌홀',300);
+--행 338
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (337,'부산광역시','기장군','장안읍 장안로 211 ','안데르센극장',241);
+--행 339
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (338,'부산광역시','기장군','일광면 이천6길 2','가마골 소극장',83);
+--행 340
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (339,'부산광역시','남구','유엔평화로76번길 1 ','부산광역시문화회관대극장',1417);
+--행 341
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (340,'부산광역시','남구','유엔평화로76번길 1 ','부산광역시문화회관중극장',783);
+--행 342
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (341,'부산광역시','남구','유엔평화로76번길 1 ','부산문화회관 사랑채극장',312);
+--행 343
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (342,'부산광역시','남구','수영로 309 ','경성대학교컨서트홀',449);
+--행 344
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (343,'부산광역시','남구','유엔평화로76번길 26  ','가람아트홀',143);
+--행 345
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (344,'부산광역시','남구','수영로 309, 1층 ','예노소극장',220);
+--행 346
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (345,'부산광역시','남구','용소로 78 ','부산예술회관 공연장',240);
+--행 347
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (346,'부산광역시','남구','용소로13번길 36-1 ','용천소극장',80);
+--행 348
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (347,'부산광역시','남구','용소로13번길 17, 7층 ','하늘바람 소극장',83);
+--행 349
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (348,'부산광역시','남구','수영로293번길 42, 지하1층 ','에저또 소극장',72);
+--행 350
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (349,'부산광역시','남구','용소로40번길 11 ','나다소극장',70);
+--행 351
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (350,'부산광역시','남구','황령대로319번가길 147, 2층 ','대동골 문화센터',140);
+--행 352
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (351,'부산광역시','남구','유엔평화로76번길 1, 부산문화회관 ','부산문화회관 챔버홀',414);
+--행 353
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (352,'부산광역시','남구','수영로 298, 산암빌딩 지하층 ','초콜릿팩토리',164);
+--행 354
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (353,'부산광역시','남구','전포대로 133, ifc몰 3층 ','드림씨어터',1727);
+--행 355
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (354,'부산광역시','남구','수영로 지하 242, 대연역 ','공간 소극장',50);
+--행 356
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (355,'부산광역시','동구','자성로133번길 16','부산시민회관 대극장',1606);
+--행 357
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (356,'부산광역시','동구','자성로133번길 16','부산시민회관 소극장',407);
+--행 358
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (357,'부산광역시','동구','자성로133번길 10','가온아트홀 1관',150);
+--행 359
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (358,'부산광역시','동구','자성로133번길 10','가온아트홀 2관',100);
+--행 360
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (359,'부산광역시','동구','자성로133번길 15','KB아트홀',318);
+--행 361
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (360,'부산광역시','동래구','문화로 80','동래문화회관 대극장',511);
+--행 362
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (361,'부산광역시','동래구','문화로 80','동래문화회관 소극장',200);
+--행 363
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (362,'부산광역시','동래구','우장춘로 195-46','송유당',189);
+--행 364
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (363,'부산광역시','동래구','온천장로 7','열린아트홀',80);
+--행 365
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (364,'부산광역시','동래구','사직북로48번길 162','글로빌아트홀',250);
+--행 366
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (365,'부산광역시','부산진구','국악로2','국립부산국악원',971);
+--행 367
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (366,'부산광역시','북구','금곡대로46번길 50','북구문화예술회관',341);
+--행 368
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (367,'부산광역시','북구','남부순환로 2346','꿈팡팡624소극장',108);
+--행 369
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (368,'부산광역시','사상구','가야대로196번길 51','다누림홀',210);
+--행 370
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (369,'부산광역시','사상구','백양대로700번길 140','신라대학교 예음관 소극장',273);
+--행 371
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (370,'부산광역시','수영구','수영로582번길 10, 지하1층','부산메트로홀',169);
+--행 372
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (371,'부산광역시','수영구','수영로 657, 지하1층','청춘나비아트홀',90);
+--행 373
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (372,'부산광역시','수영구','수영로 421-1','레몬트리소극장',100);
+--행 374
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (373,'부산광역시','수영구','남천동로 7, 지하1층','액터스소극장',60);
+--행 375
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (374,'부산광역시','수영구','수영로 765-1, 지하1층','효로민락소극장',75);
+--행 376
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (375,'부산광역시','수영구','구락로123번길 20, F1963','석천홀',450);
+--행 377
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (376,'부산광역시','영도구','함지로79번길 6','봉래홀',428);
+--행 378
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (377,'부산광역시','영도구','함지로79번길 6','절영홀',157);
+--행 379
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (378,'부산광역시','영도구','해양로 301번길 45','국립해양박물관 공연장',311);
+--행 380
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (379,'부산광역시','해운대구','양운로 97','해운대문화회관 대극장',458);
+--행 381
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (380,'부산광역시','해운대구','양운로 97','해운대문화회관 소극장',130);
+--행 382
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (381,'부산광역시','해운대구','수영강변대로 120','영화의전당 하늘연극장',841);
+--행 383
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (382,'부산광역시','해운대구','APEC로 68','국민생활관소극장',200);
+--행 384
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (383,'부산광역시','해운대구','센텀남대로 35','신세계문화홀',408);
+--행 385
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (384,'부산광역시','해운대구','센텀서로 30','KNN 시어터',297);
+--행 386
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (385,'부산광역시','해운대구','중동1로19번길 14','수 아트홀',110);
+--행 387
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (386,'부산광역시','해운대구','좌동순환로 421','Tree house',20);
+--행 388
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (387,'부산광역시','중구','중구로 71','부산카톨릭센타',200);
+--행 389
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (388,'부산광역시','중구','민주공원길 19','민주공원 중극장',419);
+--행 390
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (389,'부산광역시','중구','민주공원길 19','민주공원 소극장',100);
+--행 391
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (390,'부산광역시','중구','구덕로34번길 4 뉴남포빌딩 3층','BS부산은행 조은극장 제1관',266);
+--행 392
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (391,'부산광역시','중구','구덕로34번길 4 뉴남포빌딩 3층','BS부산은행 조은극장 제2관',172);
+--행 393
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (392,'부산광역시','사하구','낙동남로1233번길 25','을숙도문화회관 대공연장',709);
+--행 394
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (393,'부산광역시','사하구','낙동남로1233번길 25','을숙도문화회관 소공연장',242);
+--행 395
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (394,'대구광역시','동구','동대구로 461 ','대구경북디자인센터 아트홀',134);
+--행 396
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (395,'대구광역시','동구','신암북로11길 54-2 ','동부여성문화회관 공연장',300);
+--행 397
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (396,'대구광역시','동구','동부로 149 ','대구신세계 문화홀',450);
+--행 398
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (397,'대구광역시','동구','동호로 132, 2층','달과 함께 걷다',50);
+--행 399
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (398,'대구광역시','동구','효동로2길 24','아양아트센터 아양홀',1112);
+--행 400
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (399,'대구광역시','서구','당산로 403','서구문화회관',442);
+--행 401
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (400,'대구광역시','남구','앞산순환로 478','대덕문화전당 드림홀',556);
+--행 402
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (401,'대구광역시','남구','앞산순환로 478','대덕문화전당 아트홀',100);
+--행 403
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (402,'대구광역시','남구','중앙대로45길 53','대구음악창작소 창공홀',90);
+--행 404
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (403,'대구광역시','남구','효성로 37','우봉아트홀',312);
+--행 405
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (404,'대구광역시','남구','계명중앙1길 35-1','한울림소극장',90);
+--행 406
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (405,'대구광역시','남구','현충로 256 ','우전소극장',84);
+--행 407
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (406,'대구광역시','남구','현충로 265','예술극장 엑터스토리',70);
+--행 408
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (407,'대구광역시','남구','명덕로 98-1','예전아트홀',60);
+--행 409
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (408,'대구광역시','남구','현충로 148 ','꿈꾸는 씨어터',123);
+--행 410
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (409,'대구광역시','남구','명덕로 100, 5층','고도5층극장',80);
+--행 411
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (410,'대구광역시','남구','현충로 233 ','Get Space',60);
+--행 412
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (411,'대구광역시','남구','성당로60길 90','빈티지소극장',55);
+--행 413
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (412,'대구광역시','남구','명덕로 98-2','소극장 함세상',70);
+--행 414
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (413,'대구광역시','남구','현충로 244','클럽헤비',80);
+--행 415
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (414,'대구광역시','남구','명덕로 22길 27 ','소극장 길',102);
+--행 416
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (415,'대구광역시','남구','현충로 262','공연예술보호구역 아트벙커',104);
+--행 417
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (416,'대구광역시','남구','계명중앙1길 39-4, 1층 ','골목실험극장',100);
+--행 418
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (417,'대구광역시','남구','계명중앙1길 1, 지하1층','작은무대',70);
+--행 419
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (418,'대구광역시','남구','계명중앙1길 48, 지하1층','소극장 소금창고',100);
+--행 420
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (419,'대구광역시','남구','양지로 114, 지하1층','창작공간기차',70);
+--행 421
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (420,'대구광역시','남구','명덕로40길 111, 지하1층','세진음반  ',50);
+--행 422
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (421,'대구광역시','북구','구암로 47 ','대구광역시 북구 어울아트센터',434);
+--행 423
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (422,'대구광역시','북구','검단로 71-17 ','대구광역시 북구청소년회관',183);
+--행 424
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (423,'대구광역시','북구','호암로 15 ','대구오페라하우스',1508);
+--행 425
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (424,'대구광역시','북구','호암로 51 ','대구오페라하우스 카메라타',90);
+--행 426
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (425,'대구광역시','북구','경대로 109 ','경대로 소극장 냄비',50);
+--행 427
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (426,'대구광역시','중구','봉산문화길 77 ','봉산문화회관 가온홀',424);
+--행 428
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (427,'대구광역시','중구','태평로 141','대구콘서트하우스 ',1532);
+--행 429
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (428,'대구광역시','중구','달성로22길 31-12','수창홀',120);
+--행 430
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (429,'대구광역시','중구','대봉동 6-5','김광석길 야외콘서트홀',300);
+--행 431
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (430,'대구광역시','중구','동성로2가 165-1','동성로 야외무대',500);
+--행 432
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (431,'대구광역시','중구','봉산문화길 77 ','봉산문화회관 스페이스라온',90);
+--행 433
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (432,'대구광역시','중구','명덕로 333','프라임홀',214);
+--행 434
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (433,'대구광역시','중구','달구벌대로 2085','동아아트홀',124);
+--행 435
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (434,'대구광역시','중구','문우관길 47','아회아트홀',144);
+--행 436
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (435,'대구광역시','중구','중앙대로 394','문화예술전용극장 THE CITY',295);
+--행 437
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (436,'대구광역시','중구','동성로1길 29-29','하모니아아트홀1관',270);
+--행 438
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (437,'대구광역시','중구','교동길 15','송죽씨어터',260);
+--행 439
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (438,'대구광역시','중구','달구벌대로 2204','아트팩토리 청춘',70);
+--행 440
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (439,'대구광역시','중구','경상감영길 294','예술극장 온',70);
+--행 441
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (440,'대구광역시','중구','명덕로 111, 지하1층','라이브소극장 락왕',70);
+--행 442
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (441,'대구광역시','중구','동성로1길 29-29','하모니아아트홀2관',140);
+--행 443
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (442,'대구광역시','중구','동성로3길 89','아트플러스씨어터2관',135);
+--행 444
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (443,'대구광역시','중구','동성로3길 35, 4층','여우별 아트홀',156);
+--행 445
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (444,'대구광역시','중구','동덕로 36-15','떼아뜨르 분도',120);
+--행 446
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (445,'대구광역시','중구','달구벌대로414길 6, 4층','지니프로덕션',35);
+--행 447
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (446,'대구광역시','수성구','무학로 180','수성아트피아 용지홀',1159);
+--행 448
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (447,'대구광역시','수성구','무학로 180','수성아트피아 무학홀',301);
+--행 449
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (448,'대구광역시','수성구','동대구로 176','꾀꼬리극장',661);
+--행 450
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (449,'대구광역시','수성구','연호동 186-5번지 대공원역 지하2층 ','대구메트로아트센터',202);
+--행 451
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (450,'대구광역시','수성구','천을로 173, 6층','아트센터 달',192);
+--행 452
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (451,'대구광역시','달서구','공원순환로 201 ','대구문화예술회관 팔공홀',1008);
+--행 453
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (452,'대구광역시','달서구','공원순환로 201 ','대구문화예술회관 비슬홀',500);
+--행 454
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (453,'대구광역시','달서구','공원순환로 46 ','코오롱야외음악당',1080);
+--행 455
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (454,'대구광역시','달서구','문화회관길 160 ','웃는얼굴아트센터 청룡홀',460);
+--행 456
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (455,'대구광역시','달서구','문화회관길 160 ','웃는얼굴아트센터 와룡홀',212);
+--행 457
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (456,'대구광역시','달서구','앞산순환로 180 ','청소년수련원아트홀',453);
+--행 458
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (457,'대구광역시','달서구','용산로 181 ','대구학생문화센터대공연장',1441);
+--행 459
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (458,'대구광역시','달서구','용산로 181 ','대구학생문화센터소극장',159);
+--행 460
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (459,'대구광역시','달서구','달구벌대로 1611 ','푸른방송 아트홀',176);
+--행 461
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (460,'대구광역시','달서구','두류공원로 200 ','이월드 대공연장',700);
+--행 462
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (461,'대구광역시','달성군','대실역북로2길 188','달성문화센터 백년홀',302);
+--행 463
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (462,'대구광역시','달성군','현풍동로 92','달성문화원 공연장',236);
+--행 464
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (463,'광주광역시','북구','북문대로 60','문화예술회관 대극장',1722);
+--행 465
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (464,'광주광역시','북구','대천로 86','광주광역시북구청소년수련관',262);
+--행 466
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (465,'광주광역시','북구','향토문화로 65','평생학습문화센터공연장',104);
+--행 467
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (466,'광주광역시','동구','예술길 18-1','궁동예술극장',83);
+--행 468
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (467,'광주광역시','동구','중앙로160번길 22','동구문화센터',108);
+--행 469
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (468,'광주광역시','동구','금남로 250-9','광주아트홀',150);
+--행 470
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (469,'광주광역시','동구','중흥로209번길 8','문예정터 소극장',100);
+--행 471
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (470,'광주광역시','동구','금남로 218-9','공연일번지',70);
+--행 472
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (471,'광주광역시','동구','동명로 19-10','씨어터 연바람',80);
+--행 473
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (472,'광주광역시','동구','중앙로 149-2','예술극장 통',100);
+--행 474
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (473,'광주광역시','동구','문화전당로 38','문화전당 어린이극장',130);
+--행 475
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (474,'광주광역시','동구','문화전당로 38','문화전당 극장1',1056);
+--행 476
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (475,'광주광역시','동구','문화전당로 38','문화전당 극장2',512);
+--행 477
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (476,'광주광역시','동구','문화전당로 38','문화전당 극장3',248);
+--행 478
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (477,'광주광역시','동구','예술길 23-1','극단예린 소극장',36);
+--행 479
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (478,'광주광역시','동구','동계천로 111','민들레 소극장',100);
+--행 480
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (479,'광주광역시','동구','중앙로148번길 11-27','광주디엠홀',90);
+--행 481
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (480,'광주광역시','서구','내방로 152 ','5.18기념문화관',802);
+--행 482
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (481,'광주광역시','서구','학생독립로 37 ','광주광역시 청소년수련원 청소년극장',466);
+--행 483
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (482,'광주광역시','서구','상무민주로 61 ','광주학생교육문화회관',507);
+--행 484
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (483,'광주광역시','서구','풍금로 182 ','빛고을국악전수관',137);
+--행 485
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (484,'광주광역시','서구','내방로 152 ','5.18기념문화관',285);
+--행 486
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (485,'광주광역시','서구','서구 마재로 3 ','서구문화센터공연장',326);
+--행 487
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (486,'광주광역시','서구','무진대로 904 ','금호아트홀',316);
+--행 488
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (487,'광주광역시','서구','무진대로 904 ','동산아트홀',243);
+--행 489
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (488,'광주광역시','서구','상무시민로 3 ','광주공연마루',172);
+--행 490
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (489,'광주광역시','서구','상무중앙로 90, 7층 ','기분좋은극장',220);
+--행 491
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (490,'광주광역시','광산구','광산로68번길 13','광산문화예술회관',548);
+--행 492
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (491,'광주광역시','광산구','첨단중앙로182번길 39','광산구청소년수련관 공연장',250);
+--행 493
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (492,'광주광역시','광산구','장신로 98','수완레미어린이극장',304);
+--행 494
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (493,'광주광역시','남구','천변좌로 338번길 7','빛고을시민문화관 공연장',715);
+--행 495
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (494,'광주광역시','남구','천변좌로 338번길 7','빛고을아트스페이스 소공연장',100);
+--행 496
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (495,'인천광역시','중구','자유공원로 12 ','인천광역시교육청학생교육문화회관',600);
+--행 497
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (496,'인천광역시','중구','자유공원로 12 ','인천광역시교육청학생교육문화회관',220);
+--행 498
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (497,'인천광역시','중구','제물량로 238 ','한중문화관 공연장',200);
+--행 499
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (498,'인천광역시','중구','신포로27번길 3, 3층 ','다락 소극장',80);
+--행 500
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (499,'인천광역시','중구','축항대로296번길 81 ','중구문화회관',638);
+--행 501
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (500,'인천광역시','중구','제물량로218번길 3 ','인천아트플랫폼',80);
+--행 502
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (501,'인천광역시','중구','연안부두로 36 ','현대크루즈호',290);
+--행 503
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (502,'인천광역시','중구','월미문화로 21 ','뉴코스모스호 1',297);
+--행 504
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (503,'인천광역시','중구','월미문화로 21 ','뉴코스모스호 2',102);
+--행 505
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (504,'인천광역시','동구','솔빛로 82','동구청소년수련관',345);
+--행 506
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (505,'인천광역시','미추홀구','매소홀로 573','작은극장돌체',96);
+--행 507
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (506,'인천광역시','미추홀구','수봉안길 78','인천수봉문화회관 소극장',160);
+--행 508
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (507,'인천광역시','미추홀구','수봉안길 78','국악회관 공연장',118);
+--행 509
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (508,'인천광역시','미추홀구','인하로 126','학산소극장',114);
+--행 510
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (509,'인천광역시','미추홀구','매소홀로 618','문학시어터',144);
+--행 511
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (510,'인천광역시','미추홀구','연남로 35','롯데문화홀',252);
+--행 512
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (511,'인천광역시','연수구','청능대로 210, 4층 ','스퀘어 원 문화 홀',189);
+--행 513
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (512,'인천광역시','연수구','인천타워대로 250 ','트라이볼',300);
+--행 514
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (513,'인천광역시','연수구','아트센터대로 175, G-Tower ','아트센터 인천 콘서트홀',1727);
+--행 515
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (514,'인천광역시','연수구','아트센터대로 175, G-Tower ','아트센터 인천  콘서트홀',334);
+--행 516
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (515,'인천광역시','남동구','예술로149','인천문화예술회관 대공연장',1332);
+--행 517
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (516,'인천광역시','남동구','예술로149','인천문화예술회관 소공연장',486);
+--행 518
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (517,'인천광역시','남동구','예술로149','인천문화예술회관 500',440);
+--행 519
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (518,'인천광역시','남동구','장수로 42','인천광역시청소년수련관 공연장',430);
+--행 520
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (519,'인천광역시','남동구','아암대로 1437번길 32 남동소래아트홀','남동소래아트홀 소래극장',703);
+--행 521
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (520,'인천광역시','남동구','아암대로 1437번길 32 남동소래아트홀','남동소래아트홀 스튜디오제비',193);
+--행 522
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (521,'인천광역시','남동구','문화로 119-1','문화아트홀',45);
+--행 523
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (522,'인천광역시','부평구','마장로 296, 2층','레미어린이극장',185);
+--행 524
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (523,'인천광역시','부평구','아트센터로 166','부평아트센터 대공연장 해누리극장',868);
+--행 525
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (524,'인천광역시','부평구','아트센터로 166','부평아트센터 대공연장 달누리극장',338);
+--행 526
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (525,'인천광역시','부평구','마장로 24, 지하호','잔치마당',80);
+--행 527
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (526,'인천광역시','부평구','부평문화로 70, 3층','필근아 소극장',85);
+--행 528
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (527,'인천광역시','계양구','계양산로35번길 11','계양문화회관',795);
+--행 529
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (528,'인천광역시','계양구','장제로 937','청소년수련관',246);
+--행 530
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (529,'인천광역시','계양구','방축로 21','인천어린이과학관',178);
+--행 531
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (530,'인천광역시','서구','서달로 190','서구문화회관 대공연장',951);
+--행 532
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (531,'인천광역시','서구','서달로 190','서구문화회관 소공연장',200);
+--행 533
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (532,'인천광역시','서구','완정로92번길 18','검단복지회관',202);
+--행 534
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (533,'인천광역시','서구','서달로 190','가정생활문화센터',191);
+--행 535
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (534,'인천광역시','서구','원창로 92','서구청소년수련관',216);
+--행 536
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (535,'인천광역시','서구','크리스탈로 78','엘림아트센터 챔버홀',150);
+--행 537
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (536,'인천광역시','서구','크리스탈로 78','엘림아트센터 엘림홀',298);
+--행 538
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (537,'인천광역시','서구','청라커낼로 135','청라호수공원 야외음악당',500);
+--행 539
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (538,'대전광역시','서구','둔산대로 181','대전시립연정국악원 큰마당',750);
+--행 540
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (539,'대전광역시','서구','둔산대로 182','대전시립연정국악원 작은마당',338);
+--행 541
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (540,'대전광역시','서구','관저동로105번길 20','관저문예회관',254);
+--행 542
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (541,'대전광역시','서구','대덕대로 211, 10층','타임월드 공연장',177);
+--행 543
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (542,'대전광역시','서구','둔산대로 135','대전예술의전당 아트홀',1552);
+--행 544
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (543,'대전광역시','서구','둔산대로 135','대전예술의전당 앙상블홀',655);
+--행 545
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (544,'대전광역시','서구','둔산대로 201','대전광역시 평송청소년문화센터',317);
+--행 546
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (545,'대전광역시','서구','둔산대로 201','대전광역시 평송청소년문화센터',799);
+--행 547
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (546,'대전광역시','서구','계룡로553번길 38','대전서구문화원',265);
+--행 548
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (547,'대전광역시','서구','문정로 78','이수아트홀',141);
+--행 549
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (548,'대전광역시','서구','둔산대로117번길 22, 3층','아트브릿지',150);
+--행 550
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (549,'대전광역시','서구','대덕대로162번길 11','인터플레이',20);
+--행 551
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (550,'대전광역시','서구','대덕대로162번길 51, 지하1층','아트그라운드 플래닌',223);
+--행 552
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (551,'대전광역시','중구','중교로 56','대전평생학습관대강당',600);
+--행 553
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (552,'대전광역시','중구','선화서로 2','드림아트홀',100);
+--행 554
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (553,'대전광역시','중구','대종로505번길 28, 2층','상상아트홀',130);
+--행 555
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (554,'대전광역시','중구','대흥로 109','대전중구문화원 뿌리홀',181);
+--행 556
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (555,'대전광역시','중구','중앙로112번길 13','소극장고도',59);
+--행 557
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (556,'대전광역시','중구','대종로 458','아신극장1관',152);
+--행 558
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (557,'대전광역시','중구','대흥로175번길 25, 홍명프리존 지하 2,3층','믹스페이스',419);
+--행 559
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (558,'대전광역시','중구','중앙로 32','대전예술가의집 누리홀',340);
+--행 560
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (559,'대전광역시','중구','중교로 40, 지하1층','그린빈 버찌라이브하우스',50);
+--행 561
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (560,'대전광역시','중구','대종로 458, 2층','아신극장2관',194);
+--행 562
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (561,'대전광역시','중구','중앙로112번길 15, 2층','마당극장 관용',150);
+--행 563
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (562,'대전광역시','동구','동구청로 147, 12층','동구청 공연장',474);
+--행 564
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (563,'대전광역시','동구','대전천동로 508','대전청소년위캔센터',396);
+--행 565
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (564,'대전광역시','동구','대전로448번길 70, 지하101호','작은극장다함',200);
+--행 566
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (565,'대전광역시','대덕구','비래동로 43','송상헌의 난타 소극장',86);
+--행 567
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (566,'대전광역시','대덕구','대전로 1348','대덕문예회관 공연장',175);
+--행 568
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (567,'대전광역시','유성구','도안대로 591, 지하1층 104호','이음아트홀',180);
+--행 569
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (568,'대전광역시','유성구','엑스포로97번길 40, 지하1층','조이마루 아트홀',196);
+--행 570
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (569,'대전광역시','유성구','월드컵대로 32, 동관동 1층','대전광역시 어린이회관 그린나래홀',74);
+--행 571
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (570,'대전광역시','유성구','도안대로 398, 2층','여민관',184);
+--행 572
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (571,'대전광역시','유성구','테크노중앙로 50, 디티비안 C동 401호','엘클래식',100);
+--행 573
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (572,'울산광역시','중구','장춘로 110 ','소극장''폼''',70);
+--행 574
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (573,'울산광역시','중구','장춘로 114 ','토마토소극장',130);
+--행 575
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (574,'울산광역시','중구','문화의거리 24 ','소극장 푸른가시',60);
+--행 576
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (575,'울산광역시','중구','중앙길 92 ','피가로 아트홀',100);
+--행 577
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (576,'울산광역시','중구','중앙1길 7, ','피에로소극장',75);
+--행 578
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (577,'울산광역시','중구','문화의거리 14 ','사브낫바네아',150);
+--행 579
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (578,'울산광역시','중구','새즈믄해거리 48, ','도미넌트악단 소공연장&스튜디오',55);
+--행 580
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (579,'울산광역시','중구','번영로 470, ','J ART HALL',220);
+--행 581
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (580,'울산광역시','중구','문화의거리 6, ','플러그인',100);
+--행 582
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (581,'울산광역시','중구','종가로 405','문화의전당 함월홀',499);
+--행 583
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (582,'울산광역시','남구','번영로 200 ','울산광역시문화예술회관대공연장',1484);
+--행 584
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (583,'울산광역시','남구','번영로 200 ','울산광역시문화예술회관소공연장',472);
+--행 585
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (584,'울산광역시','남구','삼산중로 144 ','근로자종합복지회관',356);
+--행 586
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (585,'울산광역시','남구','삼산로 173 ','CK 아트홀',192);
+--행 587
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (586,'울산광역시','남구','번영로 160, 제니스병원타워 11층 ','제니스 문화센터',117);
+--행 588
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (587,'울산광역시','남구','번영로 177 ','예울',87);
+--행 589
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (588,'울산광역시','동구','신복로72번길 6-16','예문아트홀',90);
+--행 590
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (589,'울산광역시','동구','명덕로 10','현대예술관 소공연장',220);
+--행 591
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (590,'울산광역시','동구','바드래1길 30','한마음예술관',456);
+--행 592
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (591,'울산광역시','동구','문현3길 6','꽃바위문화관 다목적공연장',157);
+--행 593
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (592,'울산광역시','북구','염포로 599 ','현대자동차문화회관대강당',307);
+--행 594
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (593,'울산광역시','북구','산업로 1000 ','북구문화예술회관공연장',453);
+--행 595
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (594,'울산광역시','북구','진장유통로 64 ','레미어린이극장',193);
+--행 596
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (595,'울산광역시','북구','천곡남로 86, ','쇠부리체육센터 공연장',230);
+--행 597
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (596,'울산광역시','울주군','범서읍 천상중앙길 36','울주문화예술회관 공연장',387);
+--행 598
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (597,'울산광역시','울주군','웅촌면 새초천길 10 ','웅촌문화복지센터 공연장',201);
+--행 599
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (598,'울산광역시','울주군','언양읍 언양로 40-7','서울주문화센터 공연장',318);
+--행 600
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (599,'세종특별자치시','세종특별자치시','조치원읍 문예회관길22','세종문화예술회관',842);
+--행 601
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (600,'세종특별자치시','세종특별자치시','국책연구원 3로 12 비오케이아트센터 6층','비오케이 아트센터',220);
+--행 602
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (601,'경기도','수원시','팔달구 효원로307번길 20','경기아트센터 대극장',1541);
+--행 603
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (602,'경기도','수원시','팔달구 효원로307번길 20','경기아트센터 소극장',502);
+--행 604
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (603,'경기도','수원시','팔달구 효원로307번길 20','경기아트센터 야외극장',500);
+--행 605
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (604,'경기도','수원시','팔달구 팔달산로 28','수원시민회관',376);
+--행 606
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (605,'경기도','수원시','장안구 이목로24-25','수원SK아트리움 대공연장',950);
+--행 607
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (606,'경기도','수원시','장안구 이목로24-25','수원SK아트리움 소공연장',300);
+--행 608
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (607,'경기도','수원시','팔달구 동수원로 335','수원제1야외음악당 500',796);
+--행 609
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (608,'경기도','수원시','장안구 정조로 1087','수원제2야외음악당 500',500);
+--행 610
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (609,'경기도','수원시','팔달구 인계로123 KBS수원방송센터','KBS수원아트홀',190);
+--행 611
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (610,'경기도','수원시','팔달구 월드컵로310','중앙광장 상설무대',138);
+--행 612
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (611,'경기도','수원시','장안구 송원로 101','한누리아트홀',499);
+--행 613
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (612,'경기도','수원시','팔달구 권광로 293','청소년문화센터 온누리아트홀',525);
+--행 614
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (613,'경기도','수원시','팔달구 권광로 293','청소년문화센터 은하수홀',300);
+--행 615
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (614,'경기도','수원시','팔달구 행궁로88','남문로데오아트홀',188);
+--행 616
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (615,'경기도','수원시','팔달구 중부대로34번길 15','키즈홀',300);
+--행 617
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (616,'경기도','수원시','팔달구 창룡대로20','소극장어울림터',70);
+--행 618
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (617,'경기도','수원시','팔달구 권광로207번길 28, 1층','윤아트홀',40);
+--행 619
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (618,'경기도','수원시','팔달구 정조로 767-8, 2층','미리내 마술극단',99);
+--행 620
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (619,'경기도','고양시','덕양구 고양시청로 10 문예회관','고양시문예회관',468);
+--행 621
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (620,'경기도','고양시','덕양구 중앙로 633번길 25','토당청소년수련관',286);
+--행 622
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (621,'경기도','고양시','덕양구 화신로 272번길 11','우경아트홀',153);
+--행 623
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (622,'경기도','고양시','덕양구 어울림로 33','고양어울림누리 어울림극장',1218);
+--행 624
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (623,'경기도','고양시','덕양구 어울림로 33','고양어울림누리 별모래극장',374);
+--행 625
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (624,'경기도','고양시','덕양구 어울림로 33','고양어울림누리 꽃메야외극장',300);
+--행 626
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (625,'경기도','고양시','일산동구 중앙로1286, 고양아람누리','고양아람누리 아람극장',1887);
+--행 627
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (626,'경기도','고양시','일산동구 중앙로1286, 고양아람누리','고양아람누리 아람음악당',1449);
+--행 628
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (627,'경기도','고양시','일산동구 중앙로1286, 고양아람누리','고양아람누리 새라새극장',300);
+--행 629
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (628,'경기도','고양시','일산동구 중앙로1286, 고양아람누리','고양아람누리 노루목야외극장',500);
+--행 630
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (629,'경기도','고양시','일산동구 중앙로1261번길 27','벧엘뮤직홀',363);
+--행 631
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (630,'경기도','고양시','일산동구 정발산로 127, 지하1층','터 시어터',214);
+--행 632
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (631,'경기도','고양시','일산동구 무궁화로 31-16, 남정시티프라자 305호','활주로7080 공연장',10);
+--행 633
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (632,'경기도','고양시','일산동구 고봉로 795, 2층','제이제이',150);
+--행 634
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (633,'경기도','고양시','일산동구 무궁화로 31-2, 풍성프라자 305호 일부 및 306호','올리브',80);
+--행 635
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (634,'경기도','고양시','일산서구 대화동 1050-171빅마켓','극단레미일산',209);
+--행 636
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (635,'경기도','고양시','일산서구 킨텍스로 217-59 2전시장 1층 ','뽀로로파크 킨텍스점',100);
+--행 637
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (636,'경기도','고양시','일산서구 가좌동 153-9번지 송포로 297','삼뉴극장',60);
+--행 638
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (637,'경기도','용인시','수지구 포은대로 499','용인포은아트홀',1258);
+--행 639
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (638,'경기도','용인시','수지구 문정로 7번길 15','평생학습관 큰어울마당',607);
+--행 640
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (639,'경기도','용인시','처인구 중부대로 1392번길 15','용인시문예회관 처인홀',626);
+--행 641
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (640,'경기도','용인시','처인구 중부대로 1199','문화예술원 마루홀',286);
+--행 642
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (641,'경기도','용인시','수지구 죽전로 168번길 9','죽전야외음악당',680);
+--행 643
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (642,'경기도','용인시','처인구 죽전대로 61','용인어린이상상의숲 공연놀이터',150);
+--행 644
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (643,'경기도','용인시','기흥구 민속촌로 89','흥겨운극장',420);
+--행 645
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (644,'경기도','용인시','기흥구 상갈로 6','경기도어린이박물관 강당',258);
+--행 646
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (645,'경기도','용인시','처인구 포곡읍 에버랜드로 199 ','그랜드 스테이지',550);
+--행 647
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (646,'경기도','용인시','처인구 포곡읍 에버랜드로 199 ','신전무대',500);
+--행 648
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (647,'경기도','성남시','분당구 성남대로 550 ','성남시500',480);
+--행 649
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (648,'경기도','성남시','분당구 성남대로 808 ','성남아트센터오페라하우스',1808);
+--행 650
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (649,'경기도','성남시','분당구 성남대로 808 ','성남아트센터콘서트홀',1102);
+--행 651
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (650,'경기도','성남시','분당구 성남대로 808 ','성남아트센터앙상블시어터',378);
+--행 652
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (651,'경기도','성남시','분당구 불정로386번길 38 ','성남시분당서현청소년수련관',122);
+--행 653
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (652,'경기도','성남시','분당구 성남대로407번길 12 ','성남시분당정자청소년수련관',290);
+--행 654
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (653,'경기도','성남시','수정구 희망로509번길 20 ','성남시수정청소년수련관',412);
+--행 655
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (654,'경기도','성남시','중원구 둔촌대로 332 ','성남시중원청소년수련관',199);
+--행 656
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (655,'경기도','성남시','분당구 운중로225번길 37 ','성남시분당판교청소년수련관',177);
+--행 657
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (656,'경기도','성남시','분당구 분당수서로 501 ','잡월드 나래울극장',354);
+--행 658
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (657,'경기도','성남시','중원구 양현로405번길 12, 2층 티엘아이빌딩)','티엘아이아트센터',224);
+--행 659
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (658,'경기도','성남시','분당구 안골로 12-6, 301호 ','분당소극장',153);
+--행 660
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (659,'경기도','성남시','중원구 둔촌대로 77, 지층 ','깜찍이품바공연장',80);
+--행 661
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (660,'경기도','성남시','분당구 판교역로14번길 15, 성음아트센터 4층 ','성음아트센터',204);
+--행 662
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (661,'경기도','부천시','부일로365','부천시민회관 대공연장',1041);
+--행 663
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (662,'경기도','부천시','부일로366','부천시민회관 소공연장',221);
+--행 664
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (663,'경기도','부천시','장말로 107','복사골문화센터 아트홀',531);
+--행 665
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (664,'경기도','부천시','장말로 108','복사골문화센터판타지아공연장',181);
+--행 666
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (665,'경기도','부천시','성오로 172','오정아트홀',404);
+--행 667
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (666,'경기도','부천시','송내대로 239','뉴코아소극장 부천점',160);
+--행 668
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (667,'경기도','부천시','길주로 1','한국만화박물관 어린이공연장',390);
+--행 669
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (668,'경기도','화성시','노작로 134','반석아트홀',548);
+--행 670
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (669,'경기도','화성시','태안로 145','화성아트홀',712);
+--행 671
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (670,'경기도','화성시','시청로 155','누림아트홀',392);
+--행 672
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (671,'경기도','화성시','태안로 145','동탄복합문화센터 500',600);
+--행 673
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (672,'경기도','화성시','장안면 미산길 15','마법의정원',100);
+--행 674
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (673,'경기도','화성시','우정읍 이화뱅곳길 22','민들레놀이극연구소 사랑채극장',100);
+--행 675
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (674,'경기도','안산시','단원구 화랑로 312','안산문화예술의전당 해돋이극장',1592);
+--행 676
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (675,'경기도','안산시','단원구 화랑로 312','안산문화예술의전당 달맞이극장',714);
+--행 677
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (676,'경기도','안산시','단원구 화랑로 312','안산문화예술의전당 별무리극장',140);
+--행 678
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (677,'경기도','안산시','단원구 적금로 202','올림픽기념관 국민생활관',420);
+--행 679
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (678,'경기도','안산시','단원구 광덕대로 194, A관동 5층','NC소극장',180);
+--행 680
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (679,'경기도','안산시','단원구 당곡로 9, B101호','㈜글로벌 Jey 아트홀',80);
+--행 681
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (680,'경기도','안산시','단원구 대부북동 1849-31','동춘서커스 공연장',480);
+--행 682
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (681,'경기도','남양주시','진접읍 경복대로 425','우당아트홀',490);
+--행 683
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (682,'경기도','남양주시','다산중앙로 7','다산아트홀',496);
+--행 684
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (683,'경기도','남양주시','북한강로 1554','북한강 500',500);
+--행 685
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (684,'경기도','안양시','만안구 문예로36번길 16','안양아트센터 관악홀',1126);
+--행 686
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (685,'경기도','안양시','만안구 문예로36번길 16','안양아트센터 수리홀',382);
+--행 687
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (686,'경기도','안양시','동안구 평촌대로 76','평촌아트홀',638);
+--행 688
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (687,'경기도','평택시','중앙로 277','평택남부문화예술회관',606);
+--행 689
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (688,'경기도','평택시','경기대로 1366','평택북부문화예술회관',631);
+--행 690
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (689,'경기도','평택시','서동대로 1531','평택서부문화예술회관',786);
+--행 691
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (690,'경기도','평택시','현덕면 평택호길 147','한국소리터 지영희 홀',569);
+--행 692
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (691,'경기도','시흥시','은행로173번길 14','평생학습센터대공연장',440);
+--행 693
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (692,'경기도','시흥시','정왕대로233번길 21','여성비전센터 공연장',301);
+--행 694
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (693,'경기도','시흥시','은행로 179','청소년수련관 공연장',300);
+--행 695
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (694,'경기도','시흥시','산기대학로 237','KPU 아트센터',305);
+--행 696
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (695,'경기도','시흥시','소래산길 11, 시흥ABC행복학습타운 3동 지1층','어울림 소극장',85);
+--행 697
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (696,'경기도','파주시','시민회관길 33','파주시민회관 대공연장',497);
+--행 698
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (697,'경기도','파주시','시민회관길 33','파주시민회관 소공연장',324);
+--행 699
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (698,'경기도','파주시','문산읍 통일로 1680','문산행복센터 대공연장',463);
+--행 700
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (699,'경기도','파주시','문산읍 통일로 1680','문산행복센터 소공연장',100);
+--행 701
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (700,'경기도','파주시','와석순환로 415','운정행복센터 공연장',542);
+--행 702
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (701,'경기도','파주시','와석순환로 415','운정행복센터 다목적홀',200);
+--행 703
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (702,'경기도','파주시','가람로 116번길 170','솔가람아트홀',300);
+--행 704
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (703,'경기도','파주시','탄현면 헤이리마을길 82-146','예맥아트홀',230);
+--행 705
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (704,'경기도','파주시','광인사길 88','보림인형극장',120);
+--행 706
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (705,'경기도','파주시','회동길 342','아이레벨트라움벨트',400);
+--행 707
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (706,'경기도','의정부시','의정로 1, 의정부예술의전당','의정부예술의전당 대극장',1025);
+--행 708
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (707,'경기도','의정부시','의정로 1, 의정부예술의전당','의정부예술의전당 소극장',237);
+--행 709
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (708,'경기도','의정부시','평화로493번길 48','의정부아트캠프',85);
+--행 710
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (709,'경기도','의정부시','호국로 1320','의정부SKY공연홀',90);
+--행 711
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (710,'경기도','김포시','김포대로 2347-8','통진두레문화센터 공연장',226);
+--행 712
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (711,'경기도','김포시','돌문로 26','김포아트홀 공연장',503);
+--행 713
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (712,'경기도','광주시','회안대로 891','남한산성아트홀 대극장',1038);
+--행 714
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (713,'경기도','광주시','회안대로 891','남한산성아트홀 소극장',270);
+--행 715
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (714,'경기도','광주시','청석로 288-9','청석에듀씨어터',140);
+--행 716
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (715,'경기도','광명시','시청로20','광명시민회관',530);
+--행 717
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (716,'경기도','광명시','철망산로 42','광명문화원 공연장',178);
+--행 718
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (717,'경기도','광명시','오리로854번길 10 ','광명시 평생학습원',224);
+--행 719
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (718,'경기도','광명시','오리로 1018 ','광명종합사회복지관',160);
+--행 720
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (719,'경기도','광명시','오리로 703 ','광명오픈아트홀',484);
+--행 721
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (720,'경기도','광명시','하안로288번길 15, 2층 ','소나무 예술극장',250);
+--행 722
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (721,'경기도','군포시','고산로 599','군포문화예술회관 수리홀',1134);
+--행 723
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (722,'경기도','군포시','고산로 599','군포문화예술회관 철쭉홀',428);
+--행 724
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (723,'경기도','군포시','산본로 322','청소년극장',180);
+--행 725
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (724,'경기도','군포시','고산로 263','상상극장',120);
+--행 726
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (725,'경기도','하남시','신평로125','하남문화예술회관 검단홀',911);
+--행 727
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (726,'경기도','하남시','신평로125','하남문화예술회관 아랑홀',367);
+--행 728
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (727,'경기도','오산시','경기동로 41','오산문화예술회관 대공연장',800);
+--행 729
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (728,'경기도','오산시','경기동로 41','오산문화예술회관 소공연장',207);
+--행 730
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (729,'경기도','양주시','광적면 광석리 부흥로618번길 303','양주시 문화예술회관 소공연장',311);
+--행 731
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (730,'경기도','양주시','부흥로 1339번길 47','양주시 500',990);
+--행 732
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (731,'경기도','양주시','광적면 광석로 235-48','조명박물관 공연장',60);
+--행 733
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (732,'경기도','양주시','광적면 삼일로 57, 102호','오닉스',40);
+--행 734
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (733,'경기도','이천시','부악로 40','이천아트홀 대공연장',1200);
+--행 735
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (734,'경기도','이천시','부악로 40','이천아트홀 소공연장',450);
+--행 736
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (735,'경기도','구리시','아차산로 453 ','구리아트홀 코스모스대극장',600);
+--행 737
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (736,'경기도','구리시','아차산로 453 ','구리아트홀 유채꽃소극장',280);
+--행 738
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (737,'경기도','구리시','건원대로34번길 32-10 ','구리시청소년수련관 공연장',312);
+--행 739
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (738,'경기도','구리시','경춘로 261 ','롯데백화점 구리점 아동극장',96);
+--행 740
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (739,'경기도','구리시','체육관로 74, 1층 ','구리시행정복지센터공연장',265);
+--행 741
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (740,'경기도','안성시','발화대길 21','안성맞춤아트홀 대공연장',991);
+--행 742
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (741,'경기도','안성시','발화대길 21','안성맞춤아트홀 소공연장',303);
+--행 743
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (742,'경기도','안성시','보개면 남사당로 198-2','안성 남사당 공연장',727);
+--행 744
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (743,'경기도','안성시','죽산면 용설호수길 101','죽산공연장',102);
+--행 745
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (744,'경기도','포천시','군내면 청성로 111','포천 반월아트홀  대공연장',900);
+--행 746
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (745,'경기도','포천시','군내면 청성로 111','포천 반월아트홀  소공연장',249);
+--행 747
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (746,'경기도','의왕시','오전로 122','의왕여성회관 소강당',294);
+--행 748
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (747,'경기도','여주시','영릉로 125','세종국악당',400);
+--행 749
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (748,'경기도','여주시','명성로 71','명성황후생가 문예관',161);
+--행 750
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (749,'경기도','동두천시','어수로 4','동두천시민회관',480);
+--행 751
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (750,'경기도','동두천시','상패로216번길 42','동두천시 두드림 뮤직센터 ',130);
+--행 752
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (751,'경기도','가평군','가평읍 문화로 131','가평문화예술회관 대공연장',641);
+--행 753
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (752,'경기도','가평군','석봉로 100','음악역1939 뮤직홀',254);
+--행 754
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (753,'경기도','과천시','통영로 5','과천시민회관',929);
+--행 755
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (754,'경기도','과천시','통영로 5','과천시민회관',380);
+--행 756
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (755,'경기도','과천시','광명로 181','이벤트홀',940);
+--행 757
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (756,'경기도','과천시','광명로 181','삼천리대극장',2858);
+--행 758
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (757,'경기도','과천시','광명로 181','통나무무대',290);
+--행 759
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (758,'경기도','과천시','광명로 181','지구별무대 ',280);
+--행 760
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (759,'경기도','과천시','상하벌로 110','국립과천과학관 어울림홀',495);
+--행 761
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (760,'경기도','연천군','연천읍 문화로 150','연천수레울아트홀 대공연장',580);
+--행 762
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (761,'경기도','연천군','연천읍 문화로 150','연천수레울아트홀 소공연장',166);
+--행 763
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (762,'강원도','춘천시','효자상길5번길 13','춘천문화예술회관',998);
+--행 764
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (763,'강원도','춘천시','영서로 3017','춘천인형극장',497);
+--행 765
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (764,'강원도','춘천시','강원대학교길 1','백령아트센터',1600);
+--행 766
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (765,'강원도','춘천시','서부대성로 71','봄내극장 ',137);
+--행 767
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (766,'강원도','춘천시','춘천로 112','축제극장 몸짓',124);
+--행 768
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (767,'강원도','춘천시','공지로 121-1','소극장 여우',100);
+--행 769
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (768,'강원도','춘천시','세실로 267','소극장 존',90);
+--행 770
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (769,'강원도','춘천시','스포츠타운길 399번길 22','Sound HallOutside Stage',500);
+--행 771
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (770,'강원도','원주시','명륜동 589번지','치악예술관',660);
+--행 772
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (771,'강원도','원주시','명륜동 345번지','댄싱 공연장',500);
+--행 773
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (772,'강원도','원주시','무실동 1번지 ','백운아트홀',972);
+--행 774
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (773,'강원도','원주시','중앙동 118-3번지 ','중앙청소년문화의집소공연장',84);
+--행 775
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (774,'강원도','원주시','인동 242-1번지 ','씨어터컴퍼니웃끼',100);
+--행 776
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (775,'강원도','원주시','인동 222-7번지 ','인동소극장',100);
+--행 777
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (776,'강원도','원주시','문막읍 후용리 389번지 ','교실극장',80);
+--행 778
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (777,'강원도','원주시','일산동 213-1번지 지하 1층 ','드림아트홀',150);
+--행 779
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (778,'강원도','강릉시','종합운동장길 84','강릉아트센터',1383);
+--행 780
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (779,'강원도','강릉시','단오장길 1','강릉단오제전수교육관',453);
+--행 781
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (780,'강원도','강릉시','경강로2046번길 5','작은공연장 단',100);
+--행 782
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (781,'강원도','강릉시','경강로2021번길 9-1','명주예술마당',200);
+--행 783
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (782,'강원도','강릉시','정원로 54','폰테피렌체',115);
+--행 784
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (783,'강원도','동해시','평원로 15','동해문화예술회관',570);
+--행 785
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (784,'강원도','태백시','고원로 203','태백문화예술회관 대공연장',786);
+--행 786
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (785,'강원도','속초시','번영로 155','속초문화예술회관',579);
+--행 787
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (786,'강원도','삼척시','엑스포로45','삼척문화예술회관',932);
+--행 788
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (787,'강원도','홍천군','홍천읍 설악로 1792','홍천문화예술회관',497);
+--행 789
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (788,'강원도','횡성군','횡성읍 문예로 75','횡성문화예술회관',690);
+--행 790
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (789,'강원도','횡성군','횡성읍 앞들서3로 6','횡성문화원 발표회장',172);
+--행 791
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (790,'강원도','영월군','영월읍 단종로 24','영월군문화예술회관',394);
+--행 792
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (791,'강원도','평창군','평창읍 문화예술길 51','평창문화예술회관',454);
+--행 793
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (792,'강원도','평창군','대관령면 솔봉로 325','알펜시아콘서트홀',637);
+--행 794
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (793,'강원도','평창군','대관령면 솔봉로 325','대관령 500',500);
+--행 795
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (794,'강원도','평창군','용평면 갈정지길 7','평창전통민속상설공연장',304);
+--행 796
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (795,'강원도','평창군','진부면 경강로 3554','평창송어종합공연체험장',300);
+--행 797
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (796,'강원도','정선군','정선읍 애산로 51','아리랑센터 아리랑홀',612);
+--행 798
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (797,'강원도','정선군','사북읍 하이원길 265','카사시네마',235);
+--행 799
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (798,'강원도','철원군','서면 약수로 3','화강문화센터',240);
+--행 800
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (799,'강원도','화천군','화천읍 상승로 91','화천문화예술회관',493);
+--행 801
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (800,'강원도','양구군','양구읍 비봉로73번길 52','문화복지센터 공연장',309);
+--행 802
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (801,'강원도','양구군','양구읍 비봉로73번길 52-1','양구문예회관 공연장',142);
+--행 803
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (802,'강원도','인제군','비봉로44번길 100','하늘내린센터',686);
+--행 804
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (803,'강원도','고성군','간성읍 간성로 71-7','고성군문화의집',288);
+--행 805
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (804,'강원도','고성군','거진읍 자산천로 240','고성군문화복지센터 대공연장',280);
+--행 806
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (805,'강원도','고성군','거진읍 자산천로 240','고성군문화복지센터 소공연장',168);
+--행 807
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (806,'강원도','양양군','양양읍 일출로 540','양양군문화복지회관',379);
+--행 808
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (807,'강원도','양양군','현북면 하조대해안길 119, 선 ','서피비치',500);
+--행 809
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (808,'충청북도','청주시','서원구 흥덕로 69','청주 예술의전당',1493);
+--행 810
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (809,'충청북도','청주시','서원구 흥덕로 69','청주 예술의전당',296);
+--행 811
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (810,'충청북도','청주시','서원구 예체로 118-1','청주 아트홀',710);
+--행 812
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (811,'충청북도','청주시','청원구 공항로287번길 56','충청북도교육문화원 대공연장',1053);
+--행 813
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (812,'충청북도','청주시','상당구 중앙로 30, 3층','예술나눔 터',96);
+--행 814
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (813,'충청북도','청주시','서원구 수곡로 20-25','문화공간 새벽',98);
+--행 815
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (814,'충청북도','청주시','상당구 상당로69번길 12-6, 4층','씨어터 J',165);
+--행 816
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (815,'충청북도','청주시','흥덕구 풍산로 15, 2층 2C-026호','메가폴리스 아트홀',160);
+--행 817
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (816,'충청북도','청주시','상당구 단재로 26, A동 2층 1호','쇠내골',115);
+--행 818
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (817,'충청북도','청주시','청원구 공항로 237, 2층','이음아트홀',120);
+--행 819
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (818,'충청북도','충주시','중원대로 3306','호암예술관',302);
+--행 820
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (819,'충청북도','충주시','중앙로 128','충주시문화회관',923);
+--행 821
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (820,'충청북도','제천시','의림대로6길 32','제천시문화회관',660);
+--행 822
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (821,'충청북도','제천시','의림대로 125','제천시민회관',75);
+--행 823
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (822,'충청북도','보은군','보은읍 뱃들로 54','보은문화예술회관',621);
+--행 824
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (823,'충청북도','옥천군','옥천군 옥천읍 문정1길 32','옥천문화예술회관',478);
+--행 825
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (824,'충청북도','영동군','심천면국악로1길33','우리소리관',300);
+--행 826
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (825,'충청북도','영동군','심천면 국악로 18','난계국악기체험전수관',136);
+--행 827
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (826,'충청북도','영동군','영동읍 영동힐링로 117','대공연장',441);
+--행 828
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (827,'충청북도','증평군','삼보로 28','증평문화회관 공연장',492);
+--행 829
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (828,'충청북도','진천군','진천읍 문화로 69-4','화랑관',4200);
+--행 830
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (829,'충청북도','괴산군','읍내로 266','괴산문화예술회관',477);
+--행 831
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (830,'충청북도','음성군','음성군 음성읍 예술로 102','음성문화예술회관',600);
+--행 832
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (831,'충청북도','단양군','단양읍 중앙1로 32','단양문화예술회관',498);
+--행 833
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (832,'충청남도','계룡시','계룡시 엄사면 문화1로 13','계룡문화예술의전당 대공연장',718);
+--행 834
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (833,'충청남도','공주시','고마나루5','공주문예회관',622);
+--행 835
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (834,'충청남도','금산군','금산읍 금산로 1559','금산다락원 대공연장',727);
+--행 836
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (835,'충청남도','금산군','금산읍 금산로 1560','금산다락원 소공연장',230);
+--행 837
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (836,'충청남도','부여군','충청남도 부여군 규암면 백제문로 388','부여국악의전당',198);
+--행 838
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (837,'충청남도','부여군','충청남도 부여군 부여읍 금성로 5','사비마루',425);
+--행 839
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (838,'충청남도','청양군','문화예술로 187','청양문화예술회관 대공연장',727);
+--행 840
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (839,'충청남도','청양군','문화예술로 187','청양문화예술회관 소공연장',190);
+--행 841
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (840,'충청남도','홍성군','광천읍 광천로 342','광천문예회관',446);
+--행 842
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (841,'충청남도','홍성군','홍성읍 충절로951번길 16','홍성문화원 공연장',234);
+--행 843
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (842,'충청남도','홍성군','홍성읍 내포로 164','홍주문화회관',606);
+--행 844
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (843,'충청남도','논산시','충청남도 논산시 시민로 270','논산문화예술회관 대공연장',577);
+--행 845
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (844,'충청남도','논산시','충청남도 논산시 시민로 270','논산문화예술회관 소공연장',180);
+--행 846
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (845,'충청남도','보령시','성주산로 101','보령문화예술회관 대공연장',798);
+--행 847
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (846,'충청남도','보령시','성주산로 101','보령문화예술회관 소공연장',167);
+--행 848
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (847,'충청남도','예산군','예산읍 아리랑로 185-14','예산군문예회관',505);
+--행 849
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (848,'충청남도','예산군','삽교읍 도청대로 600','충청남도 문화예술회관',836);
+--행 850
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (849,'충청남도','예산군','예산읍 군청로 22','예산군청 추사홀',300);
+--행 851
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (850,'충청남도','천안시 동남구','신부2길 12','신부문화회관',998);
+--행 852
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (851,'충청남도','천안시 동남구','신부2길 13','신부문화회관',200);
+--행 853
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (852,'충청남도','천안시 서북구','성환읍 성진로 15','성환문화회관 대공연장',686);
+--행 854
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (853,'충청남도','천안시 서북구','성환읍 성진로 16','성환문화회관 소공연장',193);
+--행 855
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (854,'충청남도','천안시 서북구','번영로 156','천안시청 봉서홀',1051);
+--행 856
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (855,'충청남도','천안시 서북구','공원로 227,9층','아트홀-G',237);
+--행 857
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (856,'충청남도','천안시 동남구','천안대로 429-13','천안박물관공연장',278);
+--행 858
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (857,'충청남도','천안시 동남구','만남로43','신세계문화홀',452);
+--행 859
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (858,'충청남도','천안시 동남구','신촌1길 23','홈플러스 소극장 천안신방점',150);
+--행 860
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (859,'충청남도','천안시 동남구','옛농고1길 41','충남학생교육문화원 대공연장',1184);
+--행 861
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (860,'충청남도','천안시 동남구','옛농고1길 41','충남학생교육문화원 소공연장',298);
+--행 862
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (861,'충청남도','천안시 동남구','성남면 종합휴양지로 185','천안예술의전당 대공연장',1642);
+--행 863
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (862,'충청남도','천안시 동남구','성남면 종합휴양지로 185','천안예술의전당 소공연장',443);
+--행 864
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (863,'충청남도','서산시','문화로 52','서산시문화회관 대공연장',601);
+--행 865
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (864,'충청남도','서산시','문화로 52','서산시문화회관 소공연장',108);
+--행 866
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (865,'충청남도','아산시','아산시 남부로 92','평생학습관 극장',509);
+--행 867
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (866,'충청남도','아산시','아산시 신정로 625-4','신정호야외음악당 ',500);
+--행 868
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (867,'충청남도','아산시','아산시 시민로 456','아산시청 시민홀',462);
+--행 869
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (868,'충청남도','아산시','아산시 도고면 아산만로 171','아산코미디홀',200);
+--행 870
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (869,'충청남도','아산시','아산시 배방읍 배방로 38','배방읍 다목적공연장',172);
+--행 871
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (870,'충청남도','아산시','아산시 배방읍 모산로 137','바나나 7080 공연장',49);
+--행 872
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (871,'충청남도','당진시','무수동2길 25-21','당진문예의전당',1001);
+--행 873
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (872,'충청남도','당진시','무수동2길 25-21','당진문예의전당',300);
+--행 874
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (873,'충청남도','서천군','서천로14번길 20','서천문예의전당',200);
+--행 875
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (874,'전라북도','전주시 완산구','영경1길 17, 2동 B층 102호','울림문화공간',100);
+--행 876
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (875,'전라북도','전주시 완산구','홍산중앙로 13, 301호','한해랑 아트홀',199);
+--행 877
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (876,'전라북도','전주시 완산구','경기전길 42','한옥마을 아트홀',60);
+--행 878
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (877,'전라북도','전주시 완산구','유연로 338, 2층','숨소리문화공간 중산 아트홀',54);
+--행 879
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (878,'전라북도','전주시 완산구','전주객사4길 지하 74-11','아하 아트홀',60);
+--행 880
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (879,'전라북도','전주시 완산구','동문길 100','창작소극장',90);
+--행 881
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (880,'전라북도','전주시 완산구','백마산길 6, 지하층','움티 공연장',50);
+--행 882
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (881,'전라북도','전주시 완산구','백제대로 299, 지하1층','더 클래식 아트홀',80);
+--행 883
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (882,'전라북도','전주시 완산구','전주객사5길 67, 3층','공연예술소극장 용',60);
+--행 884
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (883,'전라북도','전주시 완산구','용머리로 36, 10층','문화공간이룸',130);
+--행 885
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (884,'전라북도','전주시 완산구','팔달로 161','전라북도예술회관',357);
+--행 886
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (885,'전라북도','전주시 완산구','전주천동로 20','한벽공연장',235);
+--행 887
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (886,'전라북도','전주시 완산구','현무1길 20','한국전통문화전당공연장',228);
+--행 888
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (887,'전라북도','전주시 완산구','서학로 95','국립무형유산원대공연장',400);
+--행 889
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (888,'전라북도','전주시 완산구','서학로 95','국립무형유산원소공연장',200);
+--행 890
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (889,'전라북도','전주시 완산구','한지길 56','전주소리문화관',200);
+--행 891
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (890,'전라북도','전주시 덕진구','권삼득로 407','덕진예술회관',486);
+--행 892
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (891,'전라북도','전주시 덕진구','권삼득로 290','전북대삼성문화회관',1493);
+--행 893
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (892,'전라북도','전주시 덕진구','소리로 31','한국소리문화전당모악당',2037);
+--행 894
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (893,'전라북도','전주시 덕진구','소리로 31','한국소리문화전당연지홀',666);
+--행 895
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (894,'전라북도','전주시 덕진구','소리로 31','한국소리문화전당',7000);
+--행 896
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (895,'전라북도','전주시 덕진구','소리로 31','한국소리문화전당명인홀',202);
+--행 897
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (896,'전라북도','전주시 덕진구','전주천동로 376','우진문화공간 예술극장',175);
+--행 898
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (897,'전라북도','전주시 덕진구','조경단로 258-18','전라북도어린이창의체험관',242);
+--행 899
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (898,'전라북도','군산시','백토로 203','군산예술의전당 대공연장',1200);
+--행 900
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (899,'전라북도','군산시','백토로 203','군산예술의전당 소공연장',450);
+--행 901
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (900,'전라북도','군산시','대학로 330','군산어린이공연장',330);
+--행 902
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (901,'전라북도','군산시','청소년회관로 75','군산청소년회관',351);
+--행 903
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (902,'전라북도 ','군산시','내항1길 57','장미공연장',77);
+--행 904
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (903,'전라북도','군산시','옥도면 신시도리 새만금방조제 2호방조제 종점부','아리울아트홀',363);
+--행 905
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (904,'전라북도','군산시','개복동 8-1','군산시민예술촌',130);
+--행 906
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (905,'전라북도','군산시','상신4길 15-6 403','극단 사람세상 소극장',40);
+--행 907
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (906,'전라북도','익산시','동서로 490','익산예술의전당',1202);
+--행 908
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (907,'전라북도','익산시','선화1로 106','익산솜리문화예술회관',584);
+--행 909
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (908,'전라북도','정읍시','시기4길 13','정읍사예술회관',603);
+--행 910
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (909,'전라북도','정읍시','중앙로 73','연지아트홀',203);
+--행 911
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (910,'전라북도','남원시','양림길 43','춘향문화예술회관 대공연장',715);
+--행 912
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (911,'전라북도','남원시','양림길 43','춘향문화예술회관 소공연장',112);
+--행 913
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (912,'전라북도','남원시','양림길 58-13','남원랜드 공연장',767);
+--행 914
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (913,'전라북도','남원시','광한북로 54','지리산소극장',99);
+--행 915
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (914,'전라북도','남원시','양림길 54','국립민속국악원 예원당',652);
+--행 916
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (915,'전라북도','남원시','양림길 54','국립민속국악원 예음헌',100);
+--행 917
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (916,'전라북도','김제시','성산길 20','김제문화예술회관',499);
+--행 918
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (917,'전라북도','김제시','성산길 20','김제문화예술회관',230);
+--행 919
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (918,'전라북도','완주군','지암로 61','완주문화예술회관 공연장',478);
+--행 920
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (919,'전라북도','완주군','삼봉로 215','완주향토예술문화회관 공연장',196);
+--행 921
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (920,'전라북도','완주군','원암로 82','산속등대 500',70);
+--행 922
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (921,'전라북도','진안군','대성길5','진안문화의집 마이홀',210);
+--행 923
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (922,'전라북도','무주군','무설로 1482','태권도원 T1 공연장',423);
+--행 924
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (923,'전라북도','장수군','한누리로 393','장수한누리전당',278);
+--행 925
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (924,'전라북도','순창군','장류로 407-11','향토회관',465);
+--행 926
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (925,'전라북도','순창군','남부순환로 2346','방랑싸롱',30);
+--행 927
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (926,'전라북도','순창군','문예회관길22','소소극장',100);
+--행 928
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (927,'전라북도','고창군','모양성로 11','고창문화의전당 공연장',625);
+--행 929
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (928,'전라북도','부안군','예술회관길11','부안예술회관공연장',499);
+--행 930
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (929,'전라북도','부안군','부안로 1783','원숭이학교공연장',546);
+--행 931
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (930,'전라북도','부안군','부안로 1783','원숭이학교다목적공연장',691);
+--행 932
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (931,'전라남도','목포시','남농로 102','목포문화예술회관',698);
+--행 933
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (932,'전라남도','목포시','부주로 312','목포시민문화체육센터',1207);
+--행 934
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (933,'전라남도','여수시','좌수영로 69','여수 시민회관',960);
+--행 935
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (934,'전라남도','여수시','좌수영로 69','여수진남문예회관',266);
+--행 936
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (935,'전라남도','여수시','예울마루로 100','여수 예울마루 ',1323);
+--행 937
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (936,'전라남도','순천시','삼산로 16','문화예술회관',914);
+--행 938
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (937,'전라남도','순천시','삼산로 16','문화예술회관',152);
+--행 939
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (938,'전라남도','광양시','광양읍 향교길 9-30','광양문화예술회관 대공연장',490);
+--행 940
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (939,'전라남도','담양군','담양읍 지침6길 29','담양문화회관',670);
+--행 941
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (940,'전라남도','구례군','양정2길11','구례문화예술회관',153);
+--행 942
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (941,'전라남도','고흥군','고흥읍 고흥로 1892-67','문화회관 김연수실',574);
+--행 943
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (942,'전라남도','보성군','보성읍 송재로 281-9','보성군문화예술회관',497);
+--행 944
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (943,'전라남도','화순군','화순읍 만연로 72-4. 2층','아트포홀',53);
+--행 945
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (944,'전라남도','장흥군','장흥읍 읍성로 96','장흥문화예술회관',496);
+--행 946
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (945,'전라남도','강진군','강진읍 영랑로1길 9','강진아트홀 대공연장',718);
+--행 947
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (946,'전라남도','강진군','강진읍 영랑로1길 9','강진아트홀 소공연장',174);
+--행 948
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (947,'전라남도','해남군','해남읍 군청길 4','해남문화예술회관',700);
+--행 949
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (948,'전라남도','무안군','창포로 8','승달문화예술회관 대공연장',502);
+--행 950
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (949,'전라남도','영광군','영광읍 천년로 13길 2-34','영광예술의전당',579);
+--행 951
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (950,'전라남도','장성군','장성읍 문화로 110','장성문화예술회관 소공연장',199);
+--행 952
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (951,'전라남도','장성군','장성읍 문화로 111','장성문화예술회관 대공연장',684);
+--행 953
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (952,'전라남도','진도군','진도읍 진도대로 7197','진도향토문화회관',630);
+--행 954
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (953,'경상북도','포항시','남구 희망대로 850','포항문화예술회관 대공연장',972);
+--행 955
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (954,'경상북도','포항시','남구 시청로 1','포항시청문화동 대잠홀 공연장',590);
+--행 956
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (955,'경상북도','포항시','북구 서동로 83 ','포항시립중앙아트홀',270);
+--행 957
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (956,'경상북도','포항시','북구 삼호로 533','포항시청소년수련관 청소년극장',323);
+--행 958
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (957,'경상북도','포항시','남구 행복길 120 효자아트홀','효자아트홀',731);
+--행 959
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (958,'경상북도','포항시','북구 호로50','경상북도교육청문화원',1146);
+--행 960
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (959,'경상북도','포항시','남구 상도로26번길5','아라떼소극장',96);
+--행 961
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (960,'경상북도','포항시','북구 불종로73 석영빌딩 5층','100씨어터',163);
+--행 962
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (961,'경상북도','경주시','알천북로 1','경주예술의전당 대공연장',1053);
+--행 963
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (962,'경상북도','경주시','알천북로 1','경주예술의전당 소공연장',330);
+--행 964
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (963,'경상북도','경주시','알천북로 1','경주예술의전당 500',500);
+--행 965
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (964,'경상북도','경주시','금성로236','서라벌문화회관',494);
+--행 966
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (965,'경상북도','경주시','경감로 614','문화센터 공연장',741);
+--행 967
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (966,'경상북도','경주시','엑스포로 55-12','신라밀레니엄파크 메인공연장',975);
+--행 968
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (967,'경상북도','경주시','엑스포로 55-12','신라밀레니엄파크 화랑공연장',805);
+--행 969
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (968,'경상북도','김천시','운동장길 3','김천시문화예술회관',920);
+--행 970
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (969,'경상북도','김천시','김천로 200','김천시립문화회관',421);
+--행 971
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (970,'경상북도','안동시','도청대로455','경북도청 동락관',886);
+--행 972
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (971,'경상북도','안동시','축제장길66','안동문화예술의전당',994);
+--행 973
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (972,'경상북도','안동시','축제장길66','안동문화예술의전당',276);
+--행 974
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (973,'경상북도','구미시','송정대로 89','구미문화예술회관',1211);
+--행 975
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (974,'경상북도','구미시','인동가산로392','강동문화복지회관',667);
+--행 976
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (975,'경상북도','구미시','구미대로22길11','레미어린이공연장',184);
+--행 977
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (976,'경상북도','구미시','금오시장로 4 아트센터 DA 3F','공터 다',100);
+--행 978
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (977,'경상북도','영주시','가흥로 257','영주문화예술회관',498);
+--행 979
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (978,'경상북도','영주시','선비로 213','영주시민회관',490);
+--행 980
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (979,'경상북도','영천시','시청로 17','영천시민회관',791);
+--행 981
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (980,'경상북도',' 문경시 ','신흥로 85','문경문화예술회관',824);
+--행 982
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (981,'경상북도',' 문경시 ','신흥로 103','문희아트홀',310);
+--행 983
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (982,'경상북도','군위군','군위읍 군청로 158','삼국유사교육문화회관 공연장',457);
+--행 984
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (983,'경상북도','의성군','의성읍 충효로68','의성문화회관 문소홀',998);
+--행 985
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (984,'경상북도','청송군','청송읍 금월로 244-30','청송문화예술회관',435);
+--행 986
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (985,'경상북도','청송군','진보면 진보로 187','진보문화체육센터',480);
+--행 987
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (986,'경상북도','영덕군','영해면 318만세길 36','예주문화예술회관',610);
+--행 988
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (987,'경상북도','고령군','대가야읍 왕릉로 30','대가야문화누리 우륵홀',638);
+--행 989
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (988,'경상북도','고령군','대가야읍 왕릉로 30','대가야문화누리 가야금홀',140);
+--행 990
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (989,'경상북도','칠곡군','왜관읍 관문로 1길','칠곡군 교육문화회관 대공연장',710);
+--행 991
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (990,'경상북도','예천군','예천읍 충효로 209-15','예천군문화회관',604);
+--행 992
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (991,'경상북도','울진군','후포면 후포삼율로 194-14','울진문화예술회관 공연장',492);
+--행 993
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (992,'경상남도','창원시','의창구 중앙대로 181','성산아트홀 대극장',1690);
+--행 994
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (993,'경상남도','창원시','의창구 중앙대로 181','성산아트홀 소극장',510);
+--행 995
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (994,'경상남도','창원시','마산회원구 삼호로 135','3·15아트센터 대극장',1182);
+--행 996
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (995,'경상남도','창원시','마산회원구 삼호로 135','3·15아트센터 소극장',455);
+--행 997
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (996,'경상남도','창원시','진해구 진해대로 325','진해문화센터 구민회관 공연장',390);
+--행 998
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (997,'경상남도','창원시','진해구 천자로 103','진해문화센터 500',500);
+--행 999
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (998,'경상남도','창원시','의창구 창이대로113번길 20','도파니아트홀',90);
+--행 1,000
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (999,'경상남도','창원시','의창구 용지로169번길 15, 602호','범블비 이벤트 아트홀',153);
+--행 1,001
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1000,'경상남도','창원시','의창구 창원대로397번길 6, 4층 263호','뉴코아아울렛소극장',162);
+--행 1,002
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1001,'경상남도','진주시','강남로 215','경상남도문화예술회관 대공연장',1528);
+--행 1,003
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1002,'경상남도','진주시','남강로1번길 96-6','진주시 전통예술회관 공연장',218);
+--행 1,004
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1003,'경상남도','진주시','진주대로 1038','현장아트홀',134);
+--행 1,005
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1004,'경상남도','진주시','내동면 내동로 213','VK아트홀',60);
+--행 1,006
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1005,'경상남도','진주시','진양호로 257, 2층 ','날개',60);
+--행 1,007
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1006,'경상남도','통영시','남망공원길 29','통영시민문화회관 대극장',880);
+--행 1,008
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1007,'경상남도','통영시','남망공원길 29','통영시민문화회관 소극장',290);
+--행 1,009
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1008,'경상남도','통영시','큰발개1길 38','통영국제음악당 콘서트홀',1309);
+--행 1,010
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1009,'경상남도','통영시','큰발개1길 38','통영국제음악당 블랙박스',254);
+--행 1,011
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1010,'경상남도','사천시','삼천포대교로 471','사천시문화예술회관',834);
+--행 1,012
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1011,'경상남도','사천시','삼천포대교로 471','사천시문화예술회관',192);
+--행 1,013
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1012,'경상남도','사천시','실안동 1244-2','사천세계문화컨텐츠 상설공연장',480);
+--행 1,014
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1013,'경상남도','김해시','분성로 225','김해문화원',218);
+--행 1,015
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1014,'경상남도','김해시','활천로285번길 14','김해시립공연장',310);
+--행 1,016
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1015,'경상남도','김해시','대청로176번길 7','장유도서관 공연장',342);
+--행 1,017
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1016,'경상남도','김해시','김해대로 2060','김해문화의전당 마루홀',1464);
+--행 1,018
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1017,'경상남도','김해시','김해대로 2060','김해문화의전당 누리홀',300);
+--행 1,019
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1018,'경상남도','김해시','김해대로 2060','김해문화의전당 애두름마당',500);
+--행 1,020
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1019,'경상남도','김해시','진영읍 김해대로 440','진영한빛도서관 누리마을',369);
+--행 1,021
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1020,'경상남도','김해시','가야테마길161','철광산공연장',448);
+--행 1,022
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1021,'경상남도','김해시','내외중앙로 35, 4층','공간EASY',120);
+--행 1,023
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1022,'경상남도','김해시','율하2로 210','김해서부문화센터 하늬홀',691);
+--행 1,024
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1023,'경상남도','김해시','진영읍 본산1로 56번길 30','명배우 봉하극장 콜로노스',98);
+--행 1,025
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1024,'경상남도','김해시','분성로 259, 4층','회현동 소극장',80);
+--행 1,026
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1025,'경상남도','밀양시','밀양대공원로 112','밀양아리랑아트센터 대공연장',810);
+--행 1,027
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1026,'경상남도','밀양시','밀양대공원로 112','밀양아리랑아트센터 소공연장',256);
+--행 1,028
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1027,'경상남도','거제시','장승로 145 ','거제문화예술회관 대극장',1209);
+--행 1,029
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1028,'경상남도','거제시','장승로 145 ','거제문화예술회관 소극장',430);
+--행 1,030
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1029,'경상남도','거제시','계룡로 175 ','거제시청소년수련관 공연장',404);
+--행 1,031
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1030,'경상남도','거제시','일운면 구조라로 73','거제월드아트서커스',450);
+--행 1,032
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1031,'경상남도','양산시','중앙로 39-1','양산문화예술회관 대공연장',834);
+--행 1,033
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1032,'경상남도','의령군','의령읍 의병로24길 31-1','의령군민문화회관 공연장',354);
+--행 1,034
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1033,'경상남도','함안군','가야읍 함안대로 619-1','함안문화예술회관',510);
+--행 1,035
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1034,'경상남도','함안군','가야읍 선왕길 1-1','함안문화원 대공연장',180);
+--행 1,036
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1035,'경상남도','창녕군','창녕읍 우포2로 1189-25','창녕문화예술회관 대공연장',496);
+--행 1,037
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1036,'경상남도','창녕군','창녕읍 우포2로 1189-25','창녕문화예술회관 소공연장',196);
+--행 1,038
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1037,'경상남도','고성군','고성읍 송학고분로 193','고성군문화체육센터 공연장',271);
+--행 1,039
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1038,'경상남도','남해군','남해읍 선소로 12','남해문화센터',212);
+--행 1,040
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1039,'경상남도','하동군','섬진강대로 2222','하동문화예술회관 대공연장',646);
+--행 1,041
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1040,'경상남도','하동군','섬진강대로 2222','하동문화예술회관 소공연장',200);
+--행 1,042
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1041,'경상남도','산청군','금서면 친환경로2631번길 12','산청군문화예술회관',497);
+--행 1,043
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1042,'경상남도','산청군','금서면 친환경로2631번길 12','산청군문화예술회관',300);
+--행 1,044
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1043,'경상남도','함양군','함양읍 필봉산길 55','함양문화예술회관 대공연장',486);
+--행 1,045
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1044,'경상남도','함양군','함양읍 필봉산길 55','함양문화예술회관 소공연장',205);
+--행 1,046
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1045,'경상남도','거창군','거창읍 수남로 2181','거창문화센터 공연장',710);
+--행 1,047
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1046,'경상남도','거창군','거창읍 수남로 2193-40','거창문화원 상살미홀',252);
+--행 1,048
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1047,'경상남도','합천군','합천읍 황강체육공원로 93','합천군문화예술회관',340);
+--행 1,049
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1048,'제주특별자치도','제주시','동광로 69','문예회관 대극장',828);
+--행 1,050
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1049,'제주특별자치도','제주시','동광로 69','문예회관 소극장',170);
+--행 1,051
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1050,'제주특별자치도','제주시','오남로 231','제주아트센터',1184);
+--행 1,052
+INSERT INTO THEATER (no, location, city, address, name, total_seat) VALUES (1051,'제주특별자치도','서귀포시','태평로 270','서귀포예술의전당',992);
+
+----------------------------------------------------------------------------------------------
+
+-- location테이블 데이터 변경
+update location set location_name='대전/세종/충청/강원' where location_code='L3';
+update location set location_name='부산/대구/경상/울산' where location_code='L4';
+select * from performance;
+
+--PERFORMANCE테이블에서 ADDRESS컬럼 공연장번호로 변경하기
+UPDATE PERFORMANCE SET PER_ADDRESS=NULL;
+ALTER TABLE PERFORMANCE MODIFY PER_ADDRESS NUMBER;
+ALTER TABLE PERFORMANCE RENAME COLUMN PER_ADDRESS TO THEATER_NO;
+
+--THEATER 테이블에 LOCATION_CODE 컬럼 추가
+ALTER TABLE THEATER ADD LOCATION_CODE VARCHAR2(20);
+-- LOCATION_CODE 제약조건 걸기
+ALTER TABLE THEATER ADD CONSTRAINT FK_THEATER_LOCATION_CODE FOREIGN KEY(LOCATION_CODE)
+                                                                            REFERENCES LOCATION(LOCATION_CODE);
+-- LOCATION_CODE 데이터 넣기
+UPDATE THEATER SET LOCATION_CODE = 'L1' WHERE LOCATION LIKE '%서울%';
+UPDATE THEATER SET LOCATION_CODE = 'L2' WHERE LOCATION LIKE '%경기%';
+UPDATE THEATER SET LOCATION_CODE = 'L2' WHERE LOCATION LIKE '%인천%';
+UPDATE THEATER SET LOCATION_CODE = 'L3' WHERE LOCATION LIKE '%대전%';
+UPDATE THEATER SET LOCATION_CODE = 'L3' WHERE LOCATION LIKE '%세종%';
+UPDATE THEATER SET LOCATION_CODE = 'L3' WHERE LOCATION LIKE '%충청%';
+UPDATE THEATER SET LOCATION_CODE = 'L3' WHERE LOCATION LIKE '%강원%';
+UPDATE THEATER SET LOCATION_CODE = 'L4' WHERE LOCATION LIKE '%부산%';
+UPDATE THEATER SET LOCATION_CODE = 'L4' WHERE LOCATION LIKE '%대구%';
+UPDATE THEATER SET LOCATION_CODE = 'L4' WHERE LOCATION LIKE '%경상%';
+UPDATE THEATER SET LOCATION_CODE = 'L4' WHERE LOCATION LIKE '%울산%';
+UPDATE THEATER SET LOCATION_CODE = 'L5' WHERE LOCATION LIKE '%광주%';
+UPDATE THEATER SET LOCATION_CODE = 'L5' WHERE LOCATION LIKE '%전라%';
+UPDATE THEATER SET LOCATION_CODE = 'L5' WHERE LOCATION LIKE '%제주%';
+
+commit;

--- a/tickets/sql/ticket.sql
+++ b/tickets/sql/ticket.sql
@@ -51,6 +51,8 @@ create table theater(
     constraints pk_theater_no primary key(theater_no)
 );
 
+drop table theater;
+
 --Location
 create table location(
     location_code varchar2(20),
@@ -84,7 +86,7 @@ create table member(
     constraints ck_member_role check(member_role in ('U','A','C')),
     constraints ck_quit_yn check(quit_yn in ('N','Y'))
 );
-
+SELECT * FROM PERFORMANCE;
 --Performance
 create table performance(
     per_no number,

--- a/tickets/src/main/java/com/kh/tickets/performance/controller/PerformanceController.java
+++ b/tickets/src/main/java/com/kh/tickets/performance/controller/PerformanceController.java
@@ -11,9 +11,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
@@ -21,6 +23,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import com.kh.tickets.common.Utils;
 import com.kh.tickets.performance.model.service.PerformanceService;
 import com.kh.tickets.performance.model.vo.Performance;
+import com.kh.tickets.performance.model.vo.PerformanceHall;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -74,9 +77,8 @@ public class PerformanceController {
 									  HttpServletRequest request,
 									  RedirectAttributes redirectAttr) {
 		
-		String address_ = request.getParameter("address_");		
-		String address = performance.getPerAddress() + " " + address_;		
-		performance.setPerAddress(address);		
+		String theaterNo = request.getParameter("searchHallNo");	
+		performance.setTheaterNo(theaterNo);	
 		
 		String saveDirectory = request.getServletContext()
 				  .getRealPath("/resources/upload/performance");
@@ -168,6 +170,23 @@ public class PerformanceController {
 		int result = performanceService.approvePerRegister(perNo);
 		redirectAttributes.addFlashAttribute("msg", result>0 ? "공연 승인성공" : "공연 승인실패");
 		return "redirect:/performance/adminApprovalPerList.do";
+	}
+	
+	@RequestMapping("/searchPerformanceHall.do")
+	public ModelAndView searchPerformanceHall(ModelAndView mav) {
+		mav.setViewName("/performance/searchPerformanceHall");
+		return mav;
+	}
+	
+	@GetMapping("/searchHall/{keyword}")
+	@ResponseBody
+	public List<PerformanceHall> searchHallName(@PathVariable("keyword") String keyword) {
+		log.debug("keyword", keyword);
+		
+		List<PerformanceHall> list = performanceService.searchHallName(keyword);
+		log.debug("list = {}", list);
+		
+		return list;
 	}
 	
 	

--- a/tickets/src/main/java/com/kh/tickets/performance/model/dao/PerformanceDAO.java
+++ b/tickets/src/main/java/com/kh/tickets/performance/model/dao/PerformanceDAO.java
@@ -3,6 +3,7 @@ package com.kh.tickets.performance.model.dao;
 import java.util.List;
 
 import com.kh.tickets.performance.model.vo.Performance;
+import com.kh.tickets.performance.model.vo.PerformanceHall;
 
 public interface PerformanceDAO {
 
@@ -17,5 +18,7 @@ public interface PerformanceDAO {
 	int approvePerRegister(int perNo);
 
 	List<Performance> adminApprovalPerList();
+
+	List<PerformanceHall> searchHallName(String keyword);
 
 }

--- a/tickets/src/main/java/com/kh/tickets/performance/model/dao/PerformanceDAOImpl.java
+++ b/tickets/src/main/java/com/kh/tickets/performance/model/dao/PerformanceDAOImpl.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 import com.kh.tickets.performance.model.vo.Performance;
+import com.kh.tickets.performance.model.vo.PerformanceHall;
 
 @Repository
 public class PerformanceDAOImpl implements PerformanceDAO {
@@ -42,6 +43,11 @@ public class PerformanceDAOImpl implements PerformanceDAO {
 	@Override
 	public List<Performance> adminApprovalPerList() {
 		return sqlSession.selectList("performance.adminApprovalPerList");
+	}
+
+	@Override
+	public List<PerformanceHall> searchHallName(String keyword) {
+		return sqlSession.selectList("performance.searchHallName", keyword);
 	}
 
 }

--- a/tickets/src/main/java/com/kh/tickets/performance/model/service/PerformanceService.java
+++ b/tickets/src/main/java/com/kh/tickets/performance/model/service/PerformanceService.java
@@ -3,6 +3,7 @@ package com.kh.tickets.performance.model.service;
 import java.util.List;
 
 import com.kh.tickets.performance.model.vo.Performance;
+import com.kh.tickets.performance.model.vo.PerformanceHall;
 
 public interface PerformanceService {
 
@@ -17,5 +18,7 @@ public interface PerformanceService {
 	int approvePerRegister(int perNo);
 
 	List<Performance> adminApprovalPerList();
+
+	List<PerformanceHall> searchHallName(String keyword);
 
 }

--- a/tickets/src/main/java/com/kh/tickets/performance/model/service/PerformanceServiceImpl.java
+++ b/tickets/src/main/java/com/kh/tickets/performance/model/service/PerformanceServiceImpl.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 
 import com.kh.tickets.performance.model.dao.PerformanceDAO;
 import com.kh.tickets.performance.model.vo.Performance;
+import com.kh.tickets.performance.model.vo.PerformanceHall;
 
 @Service
 public class PerformanceServiceImpl implements PerformanceService {
@@ -42,6 +43,11 @@ public class PerformanceServiceImpl implements PerformanceService {
 	@Override
 	public List<Performance> adminApprovalPerList() {
 		return performanceDAO.adminApprovalPerList();
+	}
+
+	@Override
+	public List<PerformanceHall> searchHallName(String keyword) {
+		return performanceDAO.searchHallName(keyword);
 	}
 
 }

--- a/tickets/src/main/java/com/kh/tickets/performance/model/vo/Performance.java
+++ b/tickets/src/main/java/com/kh/tickets/performance/model/vo/Performance.java
@@ -24,7 +24,7 @@ public class Performance implements Serializable {
 	private String perTitle;
 	private String perDirector;
 	private String perActor;
-	private String perAddress;
+	private String theaterNo;
 	private String perContent;
 	private String perImgOriginalFileName;
 	private String perImgRenamedFileName;

--- a/tickets/src/main/java/com/kh/tickets/performance/model/vo/PerformanceHall.java
+++ b/tickets/src/main/java/com/kh/tickets/performance/model/vo/PerformanceHall.java
@@ -1,0 +1,26 @@
+package com.kh.tickets.performance.model.vo;
+
+import java.io.Serializable;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class PerformanceHall implements Serializable {
+
+	private int no;
+	private String location;
+	private String city;
+	private String address;
+	private String name;
+	private int totalSeat;
+	private String locationCode;
+	
+}

--- a/tickets/src/main/resources/mapper/performance/performance-mapper.xml
+++ b/tickets/src/main/resources/mapper/performance/performance-mapper.xml
@@ -15,7 +15,7 @@
 			#{ perTitle },
 			#{ perDirector },
 			#{ perActor },
-			#{ perAddress },
+			#{ theaterNo },
 			#{ perContent },
 			#{ perImgOriginalFileName },
 			#{ perImgRenamedFileName },
@@ -79,7 +79,16 @@
 	<resultMap type="performance" id="performanceMap">
 	</resultMap>
 	
-	
+		<select id="searchHallName" resultMap="performanceHallMap">
+		select
+			*
+		from
+			theater
+		where
+			name like '%'||#{ keyword }||'%'
+	</select>
+	<resultMap type="performanceHall" id="performanceHallMap">
+	</resultMap>	
 	
 	
 </mapper>

--- a/tickets/src/main/resources/mybatis-config.xml
+++ b/tickets/src/main/resources/mybatis-config.xml
@@ -10,7 +10,6 @@
   </settings>
   
    <typeAliases>
-  	
   	<package name="com.kh.tickets"/> 
   </typeAliases>
   

--- a/tickets/src/main/webapp/WEB-INF/views/performance/adminApprovalPerList.jsp
+++ b/tickets/src/main/webapp/WEB-INF/views/performance/adminApprovalPerList.jsp
@@ -41,7 +41,7 @@
 		<td>${ per.perTitle }</td>
 		<td>${ per.perDirector }</td>
 		<td>${ per.perActor }</td>
-		<td>${ per.perAddress }</td>
+		<td>${ per.theaterNo }</td>
 		<td>${ per.perRegisterDate }</td>		
 		<td>			
 			<button type="button" 

--- a/tickets/src/main/webapp/WEB-INF/views/performance/performanceCategoryView.jsp
+++ b/tickets/src/main/webapp/WEB-INF/views/performance/performanceCategoryView.jsp
@@ -71,7 +71,7 @@
 					 alt="캣츠 포스터" height="250px" class="mb-2 img-thumbnail"/>
 			</a>
 			<h6>${ per.perTitle }</h6>
-			<p style="font-size:13px;" class="mb-0">2020.11.01-2020.11.23<br />${ per.perAddress }</p>
+			<p style="font-size:13px;" class="mb-0">2020.11.01-2020.11.23<br />${ per.theaterNo }</p>
 		</div>
 		</c:forEach>
 		</c:if>

--- a/tickets/src/main/webapp/WEB-INF/views/performance/performanceList.jsp
+++ b/tickets/src/main/webapp/WEB-INF/views/performance/performanceList.jsp
@@ -39,7 +39,7 @@
 		<td>${ per.perTitle }</td>
 		<td>${ per.perDirector }</td>
 		<td>${ per.perActor }</td>
-		<td>${ per.perAddress }</td>
+		<td>${ per.theaterNo }</td>
 		<td>${ per.perRegisterDate }</td>
 		<%-- <td>${ per.adminApproval }</td> --%>
 		<td>${ per.adminApproval eq 'Y' ? '승인' : '미승인'}</td>

--- a/tickets/src/main/webapp/WEB-INF/views/performance/performanceRegisterForm.jsp
+++ b/tickets/src/main/webapp/WEB-INF/views/performance/performanceRegisterForm.jsp
@@ -11,55 +11,8 @@
 </jsp:include>
 
 <script src="https://t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
-<script>
-/* 우편번호 API 시작 */
-    //본 예제에서는 도로명 주소 표기 방식에 대한 법령에 따라, 내려오는 데이터를 조합하여 올바른 주소를 구성하는 방법을 설명합니다.
-    function sample4_execDaumPostcode() {
-        new daum.Postcode({
-            oncomplete: function(data) {
-                // 팝업에서 검색결과 항목을 클릭했을때 실행할 코드를 작성하는 부분.
-
-                // 도로명 주소의 노출 규칙에 따라 주소를 표시한다.
-                // 내려오는 변수가 값이 없는 경우엔 공백('')값을 가지므로, 이를 참고하여 분기 한다.
-                var roadAddr = data.roadAddress; // 도로명 주소 변수
-                var extraRoadAddr = ''; // 참고 항목 변수
-
-                // 법정동명이 있을 경우 추가한다. (법정리는 제외)
-                // 법정동의 경우 마지막 문자가 "동/로/가"로 끝난다.
-                if(data.bname !== '' && /[동|로|가]$/g.test(data.bname)){
-                    extraRoadAddr += data.bname;
-                }
-                // 건물명이 있고, 공동주택일 경우 추가한다.
-                if(data.buildingName !== '' && data.apartment === 'Y'){
-                   extraRoadAddr += (extraRoadAddr !== '' ? ', ' + data.buildingName : data.buildingName);
-                }
-                // 표시할 참고항목이 있을 경우, 괄호까지 추가한 최종 문자열을 만든다.
-                if(extraRoadAddr !== ''){
-                    extraRoadAddr = ' (' + extraRoadAddr + ')';
-                }
-
-                // 우편번호와 주소 정보를 해당 필드에 넣는다.
-                document.getElementById('sample4_postcode').value = data.zonecode;
-                document.getElementById("sample4_roadAddress").value = roadAddr;
-
-                var guideTextBox = document.getElementById("guide");
-                // 사용자가 '선택 안함'을 클릭한 경우, 예상 주소라는 표시를 해준다.
-                if(data.autoRoadAddress) {
-                    var expRoadAddr = data.autoRoadAddress + extraRoadAddr;
-                    guideTextBox.innerHTML = '(예상 도로명 주소 : ' + expRoadAddr + ')';
-                    guideTextBox.style.display = 'block';
-
-                } else {
-                    guideTextBox.innerHTML = '';
-                    guideTextBox.style.display = 'none';
-                }
-            }
-        }).open();
-    }
-/* 우편번호 API 끝 */
 
 
-</script>
 
 <style>
 /*중복아이디체크관련*/
@@ -99,15 +52,10 @@ div#memberId-container span.error{color:red; font-weight:bold;}
 			</div>
 			
 			<div class="form-group">
-				<label for="sample4_datailAddress">공연주소</label>
-				<div class="align-middle">
-					<input class="form-control d-inline-block" style="width:40%;" type="text" id="sample4_postcode" placeholder="우편번호" readonly>
-					<input type="button" class="d-inline-block mx-3 btn btn-outline-primary" style="width:30%;" onclick="sample4_execDaumPostcode()" value="우편번호 찾기"><br>
-				</div>
-				<input class="form-control my-1" type="text" id="sample4_roadAddress" name="address" placeholder="도로명주소" readonly>
-				<span id="guide" style="color:#999;display:none"></span>
-				<input class="form-control" type="text" id="sample4_detailAddress" name="address_" placeholder="상세주소">
-			</div>			
+				<input type="button" class="btn btn-outline-primary" value="공연장 검색" onclick="searchHall()"/>
+				<input type="text" class="form-control" id="searchHallNo" name="searchHallNo" placeholder="공연장번호" readonly/>
+				<input type="text" class="form-control" id="searchHallName" name="searchHallName" placeholder="공연장명" readonly/>
+			</div>		
 			
 			<div class="form-group">
 		      <label class="col-form-label" for="perContent">공연소개</label>
@@ -150,7 +98,7 @@ div#memberId-container span.error{color:red; font-weight:bold;}
 		      <select class="form-control" id="locationCode" name="locationCode">
 		        <option value="L1">서울</option>
 		        <option value="L2">경기/인천</option>
-		        <option value="L3">대전/충청/강원</option>
+		        <option value="L3">대전/세종/충청/강원</option>
 		        <option value="L4">부산/대구/경상</option>
 		        <option value="L5">광주/전라/제주</option>
 		      </select>
@@ -167,19 +115,14 @@ div#memberId-container span.error{color:red; font-weight:bold;}
 
 <script>
 
+function searchHall(){
 
-$("#performanceRegisterFrm").submit(function(){
-	
-
-	var $address = $("#sample4_postcode");
-	if($address.val().trim().length == 0){
-		alert("주소를 입력해주세요.");
-		return false;
-	}
-
-	return true;
-});
-
+	window.open('${pageContext.request.contextPath}/searchPerformanceHall.do', '', 'width=800, height=600, left=200, top=200, resizable = yes');
+}
+function setValue(hallNo,hallName){
+	document.getElementById("searchHallNo").value= hallNo;
+	document.getElementById("searchHallName").value=hallName;
+}
 
 </script>
 

--- a/tickets/src/main/webapp/WEB-INF/views/performance/searchPerformanceHall.jsp
+++ b/tickets/src/main/webapp/WEB-INF/views/performance/searchPerformanceHall.jsp
@@ -1,0 +1,117 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+    pageEncoding="UTF-8"%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt"%>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions"%>
+<!-- 한글 인코딩 처리  -->
+<fmt:requestEncoding value="utf-8"/>
+<!doctype html>
+<html lang="ko">
+<head>
+	<meta charset="UTF-8" />
+	<title>공연장 검색하기</title>
+	
+		<script src="http://code.jquery.com/jquery-latest.min.js"></script>
+		
+		<!-- bootstrap js: jquery load 이후에 작성할것.-->
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
+		<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
+
+		<!-- css 시작  -->
+			<!-- journal 테마 -->
+        <link rel="stylesheet" href="${pageContext.request.contextPath }/resources/css/bootstrap.min.css" />
+		<!-- css 끝 -->
+	
+<style>
+@font-face {
+     font-family: 'S-CoreDream-3Light';
+     src: url('https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_six@1.2/S-CoreDream-3Light.woff') format('woff');
+     font-weight: normal;
+     font-style: normal;
+}
+            
+*{
+	font-family: 'S-CoreDream-3Light' !important;
+	font-size: 17px;
+}
+</style>
+	
+</head>
+<body>
+	<div class="text-center">
+		<h3 class="mt-3">공연장 검색</h3>
+		<form id="searchHallFrm" class="form-group">
+			<input type="text" class="form-control mx-auto my-2 d-inline" id="searchHallKeyword"
+				   style="width:50%;" name="searchHallKeyword" placeholder="공연장 이름 검색"/>
+			<input type="button" id="btn-searchHall"
+				   class="btn btn-primary mt-0" value="검색" />
+		</form>
+
+	</div>
+<div class="result mx-3" id="hall-result"></div>
+
+</body>
+<script>
+	$("#btn-searchHall").click(function(){
+		var $frm = $("#searchHallFrm");
+
+		var keyword = $frm.find("[name=searchHallKeyword]").val();
+
+		$.ajax({
+			url : "${ pageContext.request.contextPath }/searchHall/" + keyword,
+			dataType: "json",
+			method: "GET",
+			success : function(data){
+				console.log(data);
+				displayResultTable("hall-result", data);
+			},
+			error : function(xhr, status, err){
+				console.log("처리실패", xhr, status, err);
+			}
+
+		});
+
+	});
+
+	function displayResultTable(id, data){
+		var $container = $("#" + id);
+		var html = "<table class='table table-hover text-center'>";
+		html += "<tr class='table-primary'><th colspan='3'>주소</th><th>이름</th><th>좌석</th><th></th></tr>"
+
+		if(data.length > 0){
+			for(var i in data){
+				var hall = data[i];
+				html += "<tr>";
+				/* html += "<td>"+ hall.no +"</td>"; */
+				html += "<td>"+ hall.location +"</td>";
+				html += "<td>"+ hall.city +"</td>";
+				html += "<td>"+ hall.address +"</td>";
+				html += "<td>"+ hall.name +"</td>";
+				html += "<td>"+ hall.totalSeat +"</td>";
+				html += "<td><input type='button' class='btn btn-outline-primary' value='선택' onclick='sendData("+hall.no+",\""+hall.name+"\")'/></td>";
+				//html += "<td><input type='button' class='btn btn-outline-primary' value='선택' onclick='sendData("+hall.no+")'/></td>";
+				html += "</tr>";
+
+			}
+		}
+		else {
+			html+="<tr><td colspan='5'>검색된 결과가 없습니다.</td></tr>";
+		}
+
+		html += "</table>";
+
+		$container.html(html);
+
+	}
+
+function sendData(hallNo,hallName){
+	console.log(hallNo,hallName);
+
+	opener.setValue(hallNo, hallName);
+	
+	window.close();
+}
+
+</script>
+
+</html>


### PR DESCRIPTION
<<<merge 하시기 전에 저한테 좀 더 확인하고 싶으신 부분 있으면 알려주세요!!!>>>

테스트 해보시기 전에
theater_data수정.sql 필수로 돌려주세요!!!

데이터, 파일 수정으로 인해 오류나는 부분들 오류 안 나게끔 처리하긴 했는데
혹시라도 오류 발견하시면 알려주세요!

**location테이블 데이터 변경**
대전/충청/강원 -> 대전/세종/충청/강원
부산/대구/경상 -> 부산/대구/경상/울산

**PERFORMANCE테이블에서 ADDRESS컬럼 공연장번호로 변경**
데이터 가져올 때는 공연장 번호로 공연장 테이블하고 조인해서 주소, 공연장명 가져오기

**THEATER 테이블에 LOCATION_CODE 컬럼 추가**
location테이블하고 조인해서 사용할 수 있지 않을까 싶어서 했는데 필요없으면 후에 삭제하겠습니다!

공연 등록에서는 공연장명 선택 후에 공연장번호, 공연장명 뷰단에 뿌리되, 
데이터베이스에는 공연장 번호만 보내서 저장했습니다
후에 공연 주소 들어가는 부분은 join해서 주소 가져오는 걸로 하고자 했는데,
다른 의견 있으시면 알려주세요!