### PR TITLE
은지 - 공연 등록 -> 공연 일정 등록 이어서 연달아 등록되도록 했습니다~

### DIFF
--- a/tickets/sql/theater_data수정.sql
+++ b/tickets/sql/theater_data수정.sql
@@ -2144,6 +2144,8 @@ UPDATE THEATER SET location_CODE = 'L5' WHERE location LIKE '%광주%';
 UPDATE THEATER SET location_CODE = 'L5' WHERE location LIKE '%전라%';
 UPDATE THEATER SET location_CODE = 'L5' WHERE location LIKE '%제주%';
 
---select * from theater;
+
+--SCHEDULE테이블에서 SCH_DATE_TIME 컬럼 데이터타입 TIMESTAMP로 변경(0924)
+ALTER TABLE SCHEDULE MODIFY SCH_DATE_TIME TIMESTAMP;
 
 commit;

--- a/tickets/src/main/java/com/kh/tickets/performance/controller/PerformanceController.java
+++ b/tickets/src/main/java/com/kh/tickets/performance/controller/PerformanceController.java
@@ -3,7 +3,10 @@ package com.kh.tickets.performance.controller;
 import java.io.File;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -14,6 +17,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -72,11 +76,11 @@ public class PerformanceController {
 
 	
 	@PostMapping("/performance/performanceRegister.do")
-	public String performanceRegister(Performance performance,
+	public ModelAndView performanceRegister(Performance performance,
 			  						  @RequestParam(value="perImgFile",required=false) MultipartFile[] perImgFiles,
 			  						  @RequestParam(value="detailImgFile",required=false) MultipartFile[] detailImgFiles,
 									  HttpServletRequest request,
-									  RedirectAttributes redirectAttr) {
+									  ModelAndView mav) {
 		
 		String theaterNo = request.getParameter("searchHallNo");	
 		performance.setTheaterNo(theaterNo);	
@@ -126,7 +130,7 @@ public class PerformanceController {
 		
 		try {
 			int result = performanceService.performanceRegister(performance);
-			redirectAttr.addFlashAttribute("msg", "공연등륵 신청 성공!");
+			mav.addObject("msg", "공연등륵 신청 성공!");
 		} catch (Exception e) {
 			log.error("공연등륵 신청 오류", e);
 //			redirectAttr.addFlashAttribute("msg", "공연등륵 신청 실패!");
@@ -135,8 +139,44 @@ public class PerformanceController {
 			throw e;
 		}	
 		
+		int perNo = performanceService.getPerNo(performance.getPerTitle());
 		
-		return "redirect:/performance/performanceRegisterForm.do";
+		mav.addObject("perNo", perNo);
+		mav.setViewName("performance/performanceDateRegisterForm");
+		return mav;
+	}
+	
+	@ResponseBody
+	@PostMapping("/performance/scheduleRegister")
+	public Map<String, Object> performanceDate(@RequestBody Map<String, Object> param) {
+		
+		String schedule = param.get("date")+" "+param.get("hour")+":"+param.get("min")+":00";
+		log.debug("schedule = {}", schedule);
+		log.debug("param = {}", param);
+		
+		SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+		Date parseDate = null;
+		String msg = "일정등록 성공";
+		try {
+			parseDate = sdf.parse(schedule);
+			log.debug("parseDate = {}", parseDate);
+			param.put("parseDate", parseDate);
+			int result = performanceService.insertSchedule(param);
+			
+		} catch (Exception e) {
+			log.error("일정 등록 오류!!!!", e);
+			msg = "일정등록 실패";
+		}
+		
+		Map<String, Object> map = new HashMap<>();
+		map.put("msg", msg);
+
+		return map;
+	}
+	
+	@RequestMapping("/performance/performanceRegisterEnd")
+	public String performanceRegisterEnd() {
+		return "performance/performanceRegisterEnd";
 	}
 	
 	

--- a/tickets/src/main/java/com/kh/tickets/performance/model/dao/PerformanceDAO.java
+++ b/tickets/src/main/java/com/kh/tickets/performance/model/dao/PerformanceDAO.java
@@ -1,6 +1,7 @@
 package com.kh.tickets.performance.model.dao;
 
 import java.util.List;
+import java.util.Map;
 
 import com.kh.tickets.performance.model.vo.Performance;
 import com.kh.tickets.performance.model.vo.PerformanceHall;
@@ -27,6 +28,10 @@ public interface PerformanceDAO {
 	List<PerformanceHall> searchHallName(String keyword);
 
 	int perUpdate(Performance performance);
+
+	int getPerNo(String perTitle);
+
+	int insertSchedule(Map<String, Object> param);
 
 
 }

--- a/tickets/src/main/java/com/kh/tickets/performance/model/dao/PerformanceDAOImpl.java
+++ b/tickets/src/main/java/com/kh/tickets/performance/model/dao/PerformanceDAOImpl.java
@@ -1,6 +1,7 @@
 package com.kh.tickets.performance.model.dao;
 
 import java.util.List;
+import java.util.Map;
 
 import org.mybatis.spring.SqlSessionTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -66,4 +67,15 @@ public class PerformanceDAOImpl implements PerformanceDAO {
 		return sqlSession.update("performance.perUpdate", performance);
 	}
 
+	@Override
+	public int getPerNo(String perTitle) {
+		return sqlSession.selectOne("performance.getPerNo", perTitle);
+	}
+
+	@Override
+	public int insertSchedule(Map<String, Object> param) {
+		return sqlSession.insert("performance.insertSchedule", param);
+	}
+
+	
 }

--- a/tickets/src/main/java/com/kh/tickets/performance/model/service/PerformanceService.java
+++ b/tickets/src/main/java/com/kh/tickets/performance/model/service/PerformanceService.java
@@ -1,6 +1,7 @@
 package com.kh.tickets.performance.model.service;
 
 import java.util.List;
+import java.util.Map;
 
 import com.kh.tickets.performance.model.vo.Performance;
 import com.kh.tickets.performance.model.vo.PerformanceHall;
@@ -29,4 +30,8 @@ public interface PerformanceService {
 	List<PerformanceHall> searchHallName(String keyword);
 
 	int perUpdate(Performance performance);
+
+	int getPerNo(String perTitle);
+
+	int insertSchedule(Map<String, Object> param);
 }

--- a/tickets/src/main/java/com/kh/tickets/performance/model/service/PerformanceServiceImpl.java
+++ b/tickets/src/main/java/com/kh/tickets/performance/model/service/PerformanceServiceImpl.java
@@ -1,6 +1,7 @@
 package com.kh.tickets.performance.model.service;
 
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -65,6 +66,16 @@ public class PerformanceServiceImpl implements PerformanceService {
 	@Override
 	public int perUpdate(Performance performance) {
 		return performanceDAO.perUpdate(performance);
+	}
+
+	@Override
+	public int getPerNo(String perTitle) {
+		return performanceDAO.getPerNo(perTitle);
+	}
+
+	@Override
+	public int insertSchedule(Map<String, Object> param) {
+		return performanceDAO.insertSchedule(param);
 	}
 
 

--- a/tickets/src/main/resources/mapper/performance/performance-mapper.xml
+++ b/tickets/src/main/resources/mapper/performance/performance-mapper.xml
@@ -105,14 +105,17 @@
 	<resultMap type="performance" id="performanceMap">
 	</resultMap>
 	
-		<select id="searchHallName" resultMap="performanceHallMap">
+	<select id="searchHallName" resultMap="performanceHallMap">
 		select
 			*
 		from
 			theater
 		where
-			name like '%'||#{ keyword }||'%'
+			upper(name) like '%'||upper(#{ keyword })||'%'
 	</select>
+	
+	<resultMap type="performanceHall" id="performanceHallMap">
+	</resultMap>	
 	
 	<update id="perUpdate">
 		update 
@@ -136,8 +139,26 @@
 			per_no = #{ perNo }
 	</update>
 	
-	<resultMap type="performanceHall" id="performanceHallMap">
-	</resultMap>	
+	<select id="getPerNo" resultType="_int">
+		select 
+			per_no
+		from
+			performance
+		where
+			per_title like #{ perTitle }
+	</select>
+	
+	<insert id="insertSchedule">
+		insert into
+			schedule
+		values(
+			schedule_seq.nextval,
+			#{ perNo },
+			null,
+			#{ parseDate }
+		)
+	
+	</insert>	
 	
 	
 </mapper>

--- a/tickets/src/main/webapp/WEB-INF/views/company/companyPerList.jsp
+++ b/tickets/src/main/webapp/WEB-INF/views/company/companyPerList.jsp
@@ -89,7 +89,6 @@
 		var $frm = $("#perUpdateFrm");
 		$frm.find("[name=perNo]").val(perNo);
 		$frm.submit();
-
 	}
 </script>
 

--- a/tickets/src/main/webapp/WEB-INF/views/performance/performanceDateRegisterForm.jsp
+++ b/tickets/src/main/webapp/WEB-INF/views/performance/performanceDateRegisterForm.jsp
@@ -1,0 +1,202 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+    pageEncoding="UTF-8"%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt"%>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions"%>
+<!-- 한글 인코딩 처리  -->
+<fmt:requestEncoding value="utf-8"/>
+
+<jsp:include page="/WEB-INF/views/common/header.jsp"/>
+	<link href="${pageContext.request.contextPath }/resources/css/jsRapCalendar.css" rel="stylesheet" type="text/css">
+
+	<script src="${pageContext.request.contextPath }/resources/js/jsRapCalendar.js"></script>
+<script>
+$(document).ready(function(){
+	$('#demo').jsRapCalendar({
+	  week:6,
+		onClick:function(y,m,d){
+			var date = y+"-"+(m+1)+"-"+d;
+
+			document.getElementById("inputDate").value = date;
+		}
+	});
+
+});
+
+</script>
+
+<div class="mx-auto align-middle my-5" style="width:50%;">
+<div class="text-left d-inline">
+	<div class="d-inline">
+		<div class="date_choice text-center d-inline align-middle" >
+			<div class="tit_process tit_date_choice">
+			<h2 class="mx-auto mt-3 text-center"><small class="text-muted">공연 등록 &gt;</small> 공연일정</h2>
+			<br /><br />
+			<div class="progress mx-auto" style="width:80%;">
+			  	<div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" aria-valuenow="10" aria-valuemin="0" aria-valuemax="100" style="width: 70%"></div>
+			</div>
+		    <br /><br />
+
+				<div class="cont_process d-inline align-middle mx-3">
+					<div id="demo" class="d-inline"></div>
+				</div>
+				<div class="d-inline-block align-middle" >
+					<form action="${ pageContext.request.contextPath }/performance/performanceDate.do" 
+						  method="post" class="form-group"
+						  id="scheduleFrm">
+						<input type="hidden" name="perNo" id="perNo" value="${ perNo }" />
+						<div class="input-group my-3">
+							<div class="input-group-prepend" style="height:40px;">
+								<label for="inputDate" class="input-group-text"> 날짜 </label>
+							</div>
+							<input type="text" id="inputDate" name="inputDate" class="form-control"
+									aria-label="Sizing example input" aria-describedby="inputGroup-sizing-sm"/>
+						</div>
+						<div class="input-group my-3">
+							<div class="input-group-prepend" style="height:40px;">
+								<label for="timeHour" class="input-group-text"> 시 </label>
+							</div>
+							<select name="timeHour" id="timeHour" class="custom-select">
+								<option value="0">0시</option>
+								<option value="1">1시</option>
+								<option value="2">2시</option>
+								<option value="3">3시</option>
+								<option value="4">4시</option>
+								<option value="5">5시</option>
+								<option value="6">6시</option>
+								<option value="7">7시</option>
+								<option value="8">8시</option>
+								<option value="9">9시</option>
+								<option value="10">10시</option>
+								<option value="11">11시</option>
+								<option value="12">12시</option>
+								<option value="13">13시</option>
+								<option value="14">14시</option>
+								<option value="15">15시</option>
+								<option value="16">16시</option>
+								<option value="17">17시</option>
+								<option value="18">18시</option>
+								<option value="19">19시</option>
+								<option value="20">20시</option>
+								<option value="21">21시</option>
+								<option value="22">22시</option>
+								<option value="23">23시</option>			
+							</select>
+						</div>
+						<div class="input-group my-3">
+							<div class="input-group-prepend" style="height:40px;">
+								<label for="timeMin" class="input-group-text"> 분 </label>
+							</div>
+							<select name="timeMin" id="timeMin" class="custom-select" >
+								<option value="00">0분</option>
+								<option value="05">5분</option>
+								<option value="10">10분</option>
+								<option value="15">15분</option>
+								<option value="20">20분</option>
+								<option value="25">25분</option>
+								<option value="30">30분</option>
+								<option value="35">35분</option>
+								<option value="40">40분</option>
+								<option value="45">45분</option>
+								<option value="50">50분</option>
+								<option value="55">55분</option>
+							</select>
+						</div>
+						<div>
+							<input type="button" 
+								   class="btn btn-primary d-inline"
+								   id="btn-addSchedule" 
+								   value="추가"/>
+						</div>
+					</form>
+				</div>
+			</div>
+		</div>
+	</div>
+	
+	<br />
+	<br />
+	<br />
+	
+	<div>
+		<table class='table table-hover text-center' id="result-table">
+			<tr>
+				<th>날짜</th>
+				<th>시</th>
+				<th>분</th>
+			</tr>
+		</table>
+	</div>
+	
+	<div class="mx-auto text-center">
+		<input type="button" class="btn btn-primary" value="공연 등록 완료" onclick="location.href='${pageContext.request.contextPath}/performance/performanceRegisterEnd'"/>
+	</div>
+
+</div>
+</div>
+
+<script>
+
+$("#btn-addSchedule").click(function(){
+	var $frm = $("#scheduleFrm");
+
+	var schedule = {
+		date : $frm.find("[name=inputDate]").val(),
+		hour : $frm.find("[name=timeHour]").val(),
+		min : $frm.find("[name=timeMin]").val(),
+		perNo : $frm.find("[name=perNo]").val()
+	};
+
+	console.log("schedule="+schedule);
+
+	var jsonStr = JSON.stringify(schedule);
+	console.log("jsonStr="+jsonStr);
+	
+	$.ajax({
+		url : "${ pageContext.request.contextPath }/performance/scheduleRegister",
+		data : jsonStr,
+		method : "POST",
+		contentType : "application/json; charset=utf-8",
+		success : function(){
+				console.log();
+				displayResultTable();
+		},
+		error : function(xhr, status, err){
+				console.log("처리실패", xhr, status, err);
+		},
+		complete : function(){
+				$frm[0].reset();
+		}
+
+	});
+
+
+	
+});
+
+function displayResultTable(){
+
+	var $container = $("#result-table");
+	
+	var $frm = $("#scheduleFrm");
+
+	var date = $frm.find("[name=inputDate]").val();
+	var hour = $frm.find("[name=timeHour]").val();
+	var min= $frm.find("[name=timeMin]").val();
+
+	var html =  "<tr>";
+		html += "<td>"+date+"</td>";
+		html += "<td>"+hour+"시</td>";
+		html += "<td>"+min+"분</td>";
+		html +=	"</tr>";
+
+		$container.append(html);
+}
+
+		
+
+
+</script>
+
+<jsp:include page="/WEB-INF/views/common/footer.jsp"/>
+   

--- a/tickets/src/main/webapp/WEB-INF/views/performance/performanceRegisterEnd.jsp
+++ b/tickets/src/main/webapp/WEB-INF/views/performance/performanceRegisterEnd.jsp
@@ -1,0 +1,31 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+    pageEncoding="UTF-8"%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt"%>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions"%>
+<!-- 한글 인코딩 처리  -->
+<fmt:requestEncoding value="utf-8"/>
+
+<jsp:include page="/WEB-INF/views/common/header.jsp">
+	<jsp:param value="" name="pageTitle"/>
+</jsp:include>
+<div class="mx-auto align-middle my-5" style="width:50%;">
+<div class="text-left d-inline">
+	<div class="d-inline">
+		<div class="date_choice text-center d-inline align-middle" >
+			<div class="text-center">
+			<h2 class="mx-auto mt-3 text-center">공연등록이 완료되었습니다.</h2>
+			<br /><br />
+				<div class="progress mx-auto" style="width:80%;">
+				  	<div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" aria-valuenow="10" aria-valuemin="0" aria-valuemax="100" style="width: 100%"></div>
+				</div>
+		    <br /><br />
+		    <input type="button" class="btn btn-primary" value="공연목록 보기" onclick="location.href='${pageContext.request.contextPath }/performance/performanceList.do'"/>
+		    </div>
+		</div>
+	</div>
+</div>
+</div>
+		    
+<jsp:include page="/WEB-INF/views/common/footer.jsp"/>
+   

--- a/tickets/src/main/webapp/WEB-INF/views/performance/performanceRegisterForm.jsp
+++ b/tickets/src/main/webapp/WEB-INF/views/performance/performanceRegisterForm.jsp
@@ -30,7 +30,11 @@ div#memberId-container span.error{color:red; font-weight:bold;}
 		  method="POST"
 		  enctype="multipart/form-data">
 		<div class="mx-auto">
-		    <h2 class="mx-auto mt-3 text-center">공연 등록</h2>
+		    <h2 class="mx-auto mt-3 text-center">공연 등록 <small class="text-muted">&gt; 공연일정</small></h2>
+		    <br /><br />
+			<div class="progress">
+			  	<div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" aria-valuenow="10" aria-valuemin="0" aria-valuemax="100" style="width: 30%"></div>
+			</div>
 		    <br /><br />
 				
 			<div class="form-group" id="memberId-container">
@@ -132,7 +136,7 @@ div#memberId-container span.error{color:red; font-weight:bold;}
 		    </div>
 			
 			<div class="mx-auto" style="width:80px;">
-				<input type="submit" class="btn btn-primary" value="등록 신청"/>
+				<input type="submit" class="btn btn-primary d-inline" value="다음"/>
 			</div>
 		</div>
 	</form>


### PR DESCRIPTION
controller
- performanceRegister메소드 수정(공연객체 저장 후 공연번호 가져와서 공연일정등록 페이지로 보냄)
- performanceDate메소드(공연일정 등록 메소드)
- performanceRegisterEnd메소드 추가(공연일정까지 마치고 난 후 페이지 이동)

vo
- performance에서 java.util.Date -> java.sql.Date 임포트로 변경

mapper
- 공연장 검색 부분 수정(대소문자 구분없이 검색 가능하게) 및 공연일정 등록 sql문 추가

DB에서 아래 sql문 실행하고 테스트해주세요~
**SCHEDULE테이블에서 SCH_DATE_TIME 컬럼 데이터타입 TIMESTAMP로 변경**
ALTER TABLE SCHEDULE MODIFY SCH_DATE_TIME TIMESTAMP;

---------공연등록 후 공연일정 등록 단점?버그?--------------
공연등록 후에 제목으로 공연번호를 찾고, 일정등록 창으로 데이터 넘긴 뒤 
공연번호를 외래키로 가지고 일정을 등록하는 건데
일정등록 창에서 새로고침 할 경우, 
공연등록 양식이 한 번 더 보내져서 같은 데이터의 공연데이터가 디비에 또 들어가게 됨!
이때, 공연제목이 똑같이 저장되기 때문에 리턴되는 공연번호 결과가 여러 개가 돼서 오류 발생함ㅠㅠ
새로고침을 어케 금지해야 하나,,,
고민해봅시다!